### PR TITLE
Fix udp on servers

### DIFF
--- a/CelesteNet.Shared/Connections/CelesteNetTCPUDPConnection.cs
+++ b/CelesteNet.Shared/Connections/CelesteNetTCPUDPConnection.cs
@@ -123,10 +123,8 @@ namespace Celeste.Mod.CelesteNet {
                         // Make sure that we have a default address if sending it without an endpoint
                         if (UDP.Client.Connected) {
                             UDP.Send(raw, length);
-                        } else {
-                            if (UDPRemoteEndPoint != null) {
-                                UDP.Send(raw, length, UDPRemoteEndPoint);
-                            }
+                        } else if (UDPRemoteEndPoint != null) {
+                            UDP.Send(raw, length, UDPRemoteEndPoint);
                         }
                     }
 


### PR DESCRIPTION
The previous udp fix assumed that every single udp client would have a
connection pre-established on creation, which is not the case for the
server. This change verifies that the udp client has a default address
before attempting to send data to it.