### PR TITLE
Added support for OnlyLatest and SkipDuplicate

### DIFF
--- a/CelesteNet.Shared/DataType/Data.cs
+++ b/CelesteNet.Shared/DataType/Data.cs
@@ -19,6 +19,8 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
         public virtual bool FilterHandle(DataContext ctx) => true;
         public virtual bool FilterSend(DataContext ctx) => true;
 
+        public virtual bool ConsideredDuplicate(DataType data) => false;
+
         public virtual MetaType[] GenerateMeta(DataContext ctx)
             => Meta;
 
@@ -187,6 +189,10 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
             0b0000000000000001,
         ForceForward =
             0b0000000000000010,
+        OnlyLatest =
+            0b0000000000000100,
+        SkipDuplicate =
+            0b0000000000001000,
 
         Reserved3 =
             0b0000010000000000,

--- a/CelesteNet.Shared/DataType/DataPlayerFrame.cs
+++ b/CelesteNet.Shared/DataType/DataPlayerFrame.cs
@@ -18,7 +18,7 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
         }
 
         // Too many too quickly to make tasking worth it.
-        public override DataFlags DataFlags => DataFlags.Update;
+        public override DataFlags DataFlags => DataFlags.Update | DataFlags.OnlyLatest | DataFlags.SkipDuplicate;
 
         public uint UpdateID;
 
@@ -242,6 +242,28 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
             }
 
             writer.Write(Dead);
+        }
+
+        // Contains some sane values to figure out if this is duplicate or not
+        public override bool ConsideredDuplicate(DataType data) {
+            return data is DataPlayerFrame frame &&
+                   Position.Equals(frame.Position) &&
+                   Speed.Equals(frame.Speed) &&
+                   Scale.Equals(frame.Scale) &&
+                   Color.Equals(frame.Color) &&
+                   Facing == frame.Facing &&
+                   Depth == frame.Depth &&
+                   SpriteMode == frame.SpriteMode &&
+                   SpriteRate == frame.SpriteRate &&
+                   EqualityComparer<Vector2?>.Default.Equals(SpriteJustify, frame.SpriteJustify) &&
+                   CurrentAnimationID == frame.CurrentAnimationID &&
+                   CurrentAnimationFrame == frame.CurrentAnimationFrame &&
+                   HairColor.Equals(frame.HairColor) &&
+                   HairSimulateMotion == frame.HairSimulateMotion &&
+                   HairCount == frame.HairCount &&
+                   DashWasB == frame.DashWasB &&
+                   DashDir.Equals(frame.DashDir) &&
+                   Dead == frame.Dead;
         }
 
         public class Entity {


### PR DESCRIPTION
Added ConsideredDuplicate for Data, used with SkipDuplicate DataFlag

SkipDuplicate skips messages of the same DataType if they are considered duplicates
OnlyLatest skips messages of DataType if a later one is further back in the queue