### PR TITLE
Chat controls

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -58,9 +58,17 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         public int CursorIndex {
             get => _CursorIndex;
             set {
-                // this is "+1" because the Cursor can be at position 0 to Typing.Length
-                // where 0 is before the first char, Typing.Length-1 is before the last, and Typing.Length is after
-                _CursorIndex = value % (Typing.Length + 1);
+                if (value < 0)
+                    value = 0;
+
+                // This deliberately exceeds the Typing string's indices since the cursor
+                // 1. ... at index 0 is before the first char,
+                // 2. ... at Typing.Length-1 is before the last char,
+                // and at Typing.Length is _after_ the last char.
+                if (value > Typing.Length)
+                    value = Typing.Length;
+
+                _CursorIndex = value;
             }
         }
 
@@ -182,7 +190,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
                 _ControlHeld = MInput.Keyboard.Check(Keys.LeftControl) || MInput.Keyboard.Check(Keys.RightControl);
 
-                if(!MInput.Keyboard.Check(Keys.Left) && !MInput.Keyboard.Check(Keys.Right)) {
+                if (!MInput.Keyboard.Check(Keys.Left) && !MInput.Keyboard.Check(Keys.Right)) {
                     _CursorMoveFast = false;
                     _TimeSinceCursorMove = 0;
                 }
@@ -309,7 +317,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 _RepeatIndex = 0;
                 _Time = 0;
             } else if (!char.IsControl(c)) {
-                if(CursorIndex == Typing.Length) {
+                if (CursorIndex == Typing.Length) {
                     // Any other character - append.
                     Typing += c;
                 } else {
@@ -349,7 +357,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
                 if (!Calc.BetweenInterval(_Time, 0.5f)) {
 
-                    if(CursorIndex == Typing.Length) {
+                    if (CursorIndex == Typing.Length) {
                         offs += CelesteNetClientFont.Measure(text).X * scale;
                         CelesteNetClientFont.Draw(
                             "_",

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -272,15 +272,16 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     // extra CursorIndex check since at index=1 using trim=1 is fine
                     if (_ControlHeld && _CursorIndex > 1) {
                         // adjust Ctrl+Backspace for having a space right before cursor
+                        int _adjustedCursor = CursorIndex;
                         if (Typing[_CursorIndex - 1] == ' ')
-                            CursorIndex--;
-                        int prevWord = Typing.LastIndexOf(" ", _CursorIndex - 1);
+                            _adjustedCursor--;
+                        int prevWord = Typing.LastIndexOf(" ", _adjustedCursor - 1);
                         // if control is held and a space is found, trim from cursor back to space
                         if (prevWord >= 0)
-                            trim = _CursorIndex - prevWord;
+                            trim = _adjustedCursor - prevWord;
                         // otherwise trim whole input back from cursor as it is one word
                         else
-                            trim = _CursorIndex;
+                            trim = _adjustedCursor;
                     }
                     // remove <trim> amount of characters before cursor
                     Typing = Typing.Remove(_CursorIndex - trim, trim);

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -328,8 +328,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             if (Active) {
                 Context.RenderHelper.Rect(25f * scale, UI_HEIGHT - 125f * scale, UI_WIDTH - 50f * scale, 100f * scale, Color.Black * 0.8f);
 
-                //string prompt = "(" + Typing.IndexOf(" ", _CursorIndex) + (_directionHeldLast ? "+" : "-") + (_CursorMoveFast ? "^" : "-") + Typing.LastIndexOf(" ", _CursorIndex - (_CursorIndex > 0 ? 1 : 0)) + ") >";
-                
                 CelesteNetClientFont.Draw(
                     ">",
                     new(50f * scale, UI_HEIGHT - 105f * scale),


### PR DESCRIPTION
 - `Left`/`Right` arrow keys move cursor
 - `Ctrl-Left`/`Ctrl-Right` moves cursor between words

 - `Backspace` works at cursor of course
 - `Ctrl-Backspace` removes entire word

 - `Delete` key works as one would expect
 - `Ctrl-Delete` removes entire word

there's also some extra logic so that holding down a direction has an initial delay before continuous movement