### PR TITLE
Mac os crash at launch fix

### DIFF
--- a/CelesteNet.Shared/StringDedupeContext.cs
+++ b/CelesteNet.Shared/StringDedupeContext.cs
@@ -19,7 +19,7 @@ namespace Celeste.Mod.CelesteNet {
             public readonly List<string> Strings = new();
         }
 
-        private struct CountingUpdate {
+        private class CountingUpdate {
             public int Key;
             public int? Value;
             public CountingUpdate(int key, int? value) {

--- a/CelesteNet.Shared/StringMap.cs
+++ b/CelesteNet.Shared/StringMap.cs
@@ -26,7 +26,7 @@ namespace Celeste.Mod.CelesteNet {
     */
     public class StringMap {
 
-        private struct CountingUpdate {
+        private class CountingUpdate {
             public string Key;
             public int? Value;
             public CountingUpdate(string key, int? value) {


### PR DESCRIPTION
It seems like macOS really doesn't like structs :/
Even though the mod crashed when fetching types from assemblies when initializing DataContext, this is the actual source of the crash.
I don't know why exactly...