### PR TITLE
Make UDP listener multithreaded

### DIFF
--- a/CelesteNet.Server/CelesteNetServerSettings.cs
+++ b/CelesteNet.Server/CelesteNetServerSettings.cs
@@ -30,6 +30,7 @@ namespace Celeste.Mod.CelesteNet.Server {
         public string UserDataRoot { get; set; } = "UserData";
 
         public int MainPort { get; set; } = 3802;
+        public int NumUDPThreads { get; set; } = -1;
 
         public LogLevel LogLevel {
             get => Logger.Level;

--- a/CelesteNet.Server/TCPUDPServer.cs
+++ b/CelesteNet.Server/TCPUDPServer.cs
@@ -21,7 +21,7 @@ namespace Celeste.Mod.CelesteNet.Server {
 
         private const int SOL_SOCKET = 1, SO_REUSEPORT = 15;
         [DllImport("libc", SetLastError = true)] 
-        private static extern int setsockopt(IntPtr socket, int level, int opt, in int[] val, int len);
+        private static extern int setsockopt(IntPtr socket, int level, int opt, [In, MarshalAs(UnmanagedType.LPArray)] int[] val, int len);
 
         public readonly CelesteNetServer Server;
 
@@ -61,7 +61,7 @@ namespace Celeste.Mod.CelesteNet.Server {
                 udpSocket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
                 udpSocket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.ReuseAddress, true);
 
-                // Some Linux runtimes don't also set SO_REUSPORT, so set that manualy
+                // Some Linux runtimes don't also set SO_REUSPORT, so set that explicitly
                 if (Environment.OSVersion.Platform == PlatformID.Unix) {
                     if (setsockopt(udpSocket.Handle, SOL_SOCKET, SO_REUSEPORT, new[] { 1 }, sizeof(int)) < 0) {
                         // Even though the method is named GetLastWin32Error, it still works on Linux

--- a/CelesteNet.Server/TCPUDPServer.cs
+++ b/CelesteNet.Server/TCPUDPServer.cs
@@ -24,10 +24,10 @@ namespace Celeste.Mod.CelesteNet.Server {
         public readonly CelesteNetServer Server;
 
         protected TcpListener? TCPListener;
-        protected UdpClient?[] UDPs;
+        protected UdpClient[]? UDPs;
 
         private Thread? TCPListenerThread;
-        private Thread?[] UDPReadThreads;
+        private Thread[]? UDPReadThreads;
 
         private uint UDPNextID = (uint) (DateTime.UtcNow.Ticks / TimeSpan.TicksPerSecond);
         private readonly ConcurrentDictionary<CelesteNetTCPUDPConnection, UDPPendingKey> UDPKeys = new();
@@ -64,8 +64,8 @@ namespace Celeste.Mod.CelesteNet.Server {
             }
             Logger.Log(LogLevel.CRI, "tcpudp", $"Starting {numUdpThreads} UDP threads");
 
-            UDPs = new UdpClient?[numUdpThreads];
-            UDPReadThreads = new Thread?[numUdpThreads];
+            UDPs = new UdpClient[numUdpThreads];
+            UDPReadThreads = new Thread[numUdpThreads];
             for (int i = 0; i < numUdpThreads; i++) {
                 Socket udpSocket = new(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
                 udpSocket.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
@@ -111,7 +111,8 @@ namespace Celeste.Mod.CelesteNet.Server {
             Logger.Log(LogLevel.INF, "tcpudp", "Shutdown");
 
             TCPListener?.Stop();
-            foreach (UdpClient? UDP in UDPs) UDP?.Close();
+            if (UDPs != null) 
+                foreach (UdpClient UDP in UDPs) UDP.Close();
 
             Server.Data.UnregisterHandlersIn(this);
         }
@@ -166,7 +167,7 @@ namespace Celeste.Mod.CelesteNet.Server {
             try {
                 using MemoryStream stream = new();
                 using CelesteNetBinaryReader reader = new(Server.Data, null, stream);
-                while (Server.IsAlive && UDPs[idx] != null) {
+                while (Server.IsAlive && UDPs?[idx] != null) {
                     IPEndPoint? remote = null;
                     byte[] raw;
                     try {

--- a/CelesteNet.Server/TCPUDPServer.cs
+++ b/CelesteNet.Server/TCPUDPServer.cs
@@ -57,9 +57,9 @@ namespace Celeste.Mod.CelesteNet.Server {
                 // Determine suitable number of UDP threads
                 // On Windows, having multiple threads isn't an advantage at all, so start only one
                 // On Linux/MacOS, spawn one thread for each logical core
-                if (Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX) 
-                    numUdpThreads = 1; 
-                else 
+                if (Environment.OSVersion.Platform != PlatformID.Unix && Environment.OSVersion.Platform != PlatformID.MacOSX)
+                    numUdpThreads = 1;
+                else
                     numUdpThreads = Environment.ProcessorCount;
             }
             Logger.Log(LogLevel.CRI, "tcpudp", $"Starting {numUdpThreads} UDP threads");
@@ -112,7 +112,8 @@ namespace Celeste.Mod.CelesteNet.Server {
 
             TCPListener?.Stop();
             if (UDPs != null) 
-                foreach (UdpClient UDP in UDPs) UDP.Close();
+                foreach (UdpClient UDP in UDPs) 
+                    UDP.Close();
 
             Server.Data.UnregisterHandlersIn(this);
         }


### PR DESCRIPTION
Make the `TCPUDPServer` create multiple UDP listener sockets and threads, all handling packets at the same time. We don't have to worry about locking as connections are (should be?) thread safe, and UDP doesn't guarantee packet ordering. The sockets are created with the `SO_REUSEADDRESS` option, which on Linux also enables `SO_REUSEPORT` (https://github.com/mono/mono/blob/f11a3a4bbc36b2a18af0077cc53e7cee517615f7/mono/metadata/w32socket-unix.c#L968), which causes the Linux kernel to distribute the packets evenly under all sockets.