### PR TITLE
Player list splitting

### DIFF
--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -83,6 +83,10 @@ namespace Celeste.Mod.CelesteNet.Client {
         public CelesteNetPlayerListComponent.LocationModes ShowPlayerListLocations { get; set; } = CelesteNetPlayerListComponent.LocationModes.ON;
         [SettingIgnore]
         public bool PlayerListShortenRandomizer { get; set; } = true;
+#if !DEBUG
+        [SettingIgnore]
+#endif
+        public bool PlayerListAllowSplit { get; set; } = true;
 
         public CelesteNetChatComponent.ChatMode ShowNewMessages { get; set; }
 

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -165,8 +165,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
             Vector2 sizeAll = Vector2.Zero;
 
-            for (int i = 0; i < list.Count; i++) {
-                Blob blob = list[i];
+            foreach (Blob blob in list) {
                 blob.DynScale = Calc.LerpClamp(scale, textScale, blob.ScaleFactor);
                 blob.Dyn.Y = sizeAll.Y;
 

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -28,9 +28,32 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         public bool Active;
 
         private List<Blob> List = new();
+
         private Vector2 SizeAll;
         private Vector2 SizeUpper;
         private Vector2 SizeColumn;
+
+        /*
+         SizeAll - outer dimensions
+        +------------------------------------+
+        |                                    |
+        |            own channel             |
+        |                                    |
+        |             SizeUpper              |
+        |                                    |
+        +-----------------+------------------+
+        |                 |                  |
+        |                 |                  |
+        |   SizeColumn    |  (calculated     |
+        |                 |   from other     |
+        |                 |   three sizes)   |
+        |                 |                  |
+        |(extends all ->  |                  |
+        | the way right   |                  |
+        | if single-col)  |                  |
+        +-----------------+------------------+
+        When not in Channel Mode, only SizeAll gets used.
+         */
 
         public DataChannelList Channels;
 


### PR DESCRIPTION
I think this isn't terrible in case you wanted to take a look at it. 🙂 

I just hope there isn't any broken edge cases that I haven't thought of...

**Oh and a description of what this does for the record:**
Changes the normal "Channels" player list view, so that at a certain amount of players outside your own channel - since own channel and its players are always at the top and can include location info - the bottom of the list may split into two columns to make better use of the space the list takes up.
Slightly complicates the player list "rebuilding" process.