### PR TITLE
Control panel actions (pause chat autoscroll, etc.)

### DIFF
--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
@@ -218,6 +218,7 @@ main {
 .settings-group {
     padding: 0;
     margin: 0 0 16px 0;
+    border: 0px;
 }
 .settings-group .row {
     margin: 0 0 8px 0;

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
@@ -133,6 +133,16 @@ app {
     display: none !important;
 }
 
+.minimized span {
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+}
+
+.button-fade {
+    opacity: 50%;
+}
+
 /* #splash inlined */
 #splash.hidden {
     display: block !important;

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dialog.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dialog.js
@@ -24,11 +24,13 @@ export class FrontendDialog {
 
   settingsCP() {
     const row = (body) => el => rd$(el)`<span class="row">${body}</span>`;
-      const form = (id, body) => el => {
-          el = rd$(el)`<form>${body}</form>`;
-          el.id = id;
-          return el;
-      }
+
+    const form = (id, body) => el => {
+      el = rd$(el)`<form>${body}</form>`;
+      el.id = id;
+      return el;
+    }
+
     const fieldset = (...items) => el => {
       el = rd$(el)`<fieldset class="settings-group"></fieldset>`;
 
@@ -40,7 +42,8 @@ export class FrontendDialog {
 
       return el;
     }
-    const input = (id, gen, formid) => el => {
+
+    const input = (formid, id, gen) => el => {
       el = gen(el);
       el.id = id;
       let input = el.querySelector("input");
@@ -59,8 +62,8 @@ export class FrontendDialog {
       body: el => rd$(el)`
       <div>
         ${form("settings-form", fieldset(
-            row(input("setting-sensitive", mdcrd.checkbox("Show sensitive data", s.sensitive), "settings-form")),
-            row(input("setting-minimizeServerMsgs", mdcrd.checkbox("Collapse join messages (MOTD)", s.minimizeServerMsgs), "settings-form"))
+          row(input("settings-form", "setting-sensitive", mdcrd.checkbox("Show sensitive data", s.sensitive))),
+          row(input("settings-form", "setting-minimizeServerMsgs", mdcrd.checkbox("Collapse join messages (MOTD)", s.minimizeServerMsgs)))
         ))}
       </div>`,
       defaultButton: "yes",

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dialog.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dialog.js
@@ -23,9 +23,14 @@ export class FrontendDialog {
   }
 
   settingsCP() {
-    const row = (label, body) => el => rd$(el)`<span class="row"><span class="label">${label}</span><span class="body">${body}</span></span>`;
-    const group = (...items) => el => {
-      el = rd$(el)`<ul class="settings-group"></ul>`;
+    const row = (body) => el => rd$(el)`<span class="row">${body}</span>`;
+      const form = (id, body) => el => {
+          el = rd$(el)`<form>${body}</form>`;
+          el.id = id;
+          return el;
+      }
+    const fieldset = (...items) => el => {
+      el = rd$(el)`<fieldset class="settings-group"></fieldset>`;
 
       let list = new RDOMListHelper(el);
       for (let i in items) {
@@ -35,9 +40,15 @@ export class FrontendDialog {
 
       return el;
     }
-    const id = (id, gen) => el => {
+    const input = (id, gen, formid) => el => {
       el = gen(el);
       el.id = id;
+      let input = el.querySelector("input");
+      let label = el.querySelector("label");
+      input.id = `${id}-input`;
+      label.setAttribute("for", input.id);
+      input.setAttribute("form", formid);
+      label.setAttribute("form", formid);
       return el;
     }
 
@@ -47,10 +58,10 @@ export class FrontendDialog {
       title: "Settings: Control Panel",
       body: el => rd$(el)`
       <div>
-        ${group(
-          id("setting-sensitive", mdcrd.checkbox("Show sensitive data", s.sensitive)),
-          id("setting-minimizeServerMsgs", mdcrd.checkbox("Collapse join messages (MOTD)", s.minimizeServerMsgs))
-        )}
+        ${form("settings-form", fieldset(
+            row(input("setting-sensitive", mdcrd.checkbox("Show sensitive data", s.sensitive), "settings-form")),
+            row(input("setting-minimizeServerMsgs", mdcrd.checkbox("Collapse join messages (MOTD)", s.minimizeServerMsgs), "settings-form"))
+        ))}
       </div>`,
       defaultButton: "yes",
       buttons: ["Cancel", "OK"],

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dialog.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dialog.js
@@ -48,7 +48,8 @@ export class FrontendDialog {
       body: el => rd$(el)`
       <div>
         ${group(
-          id("setting-sensitive", mdcrd.checkbox("Show sensitive data", s.sensitive))
+          id("setting-sensitive", mdcrd.checkbox("Show sensitive data", s.sensitive)),
+          id("setting-minimizeServerMsgs", mdcrd.checkbox("Collapse join messages (MOTD)", s.minimizeServerMsgs))
         )}
       </div>`,
       defaultButton: "yes",
@@ -71,6 +72,7 @@ export class FrontendDialog {
         if (action !== "1")
           return;
         s.sensitive = el.querySelector("#setting-sensitive input")["checked"];
+        s.minimizeServerMsgs = el.querySelector("#setting-minimizeServerMsgs input")["checked"];
         s.save();
         this.frontend.dom.render();
       }

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/settings.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/settings.js
@@ -38,6 +38,15 @@ export class FrontendSettings {
     this.data.sensitive = value;
   }
 
+
+  /** @type {boolean} */
+  get minimizeServerMsgs() {
+    return this.data.minimizeServerMsgs;
+  }
+  set minimizeServerMsgs(value) {
+    this.data.minimizeServerMsgs = value;
+  }
+
   /** @type {boolean} */
   get accountsClutter() {
     return this.data.accountsClutter;

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -34,29 +34,29 @@ export class FrontendChatPanel extends FrontendBasicPanel {
       [
         "Pause", "pause",
         () => {
-            this.paused = !this.paused;
-            this.render();
-            if (!this.paused)
-                this.refresh();
+          this.paused = !this.paused;
+          this.render();
+          if (!this.paused)
+            this.refresh();
         }
       ],
 
       [
         "Auto-scroll", "vertical_align_bottom",
         () => {
-            this.autoscroll = !this.autoscroll;
-            this.refresh();
+          this.autoscroll = !this.autoscroll;
+          this.refresh();
         }
       ],
 
       [
           "Shorten Server messages", this.frontend.settings.minimizeServerMsgs ? "short_text" : "notes",
         () => {
-            this.frontend.settings.minimizeServerMsgs = !this.frontend.settings.minimizeServerMsgs;
-            this.frontend.settings.save();
-            this.actions[2][1] = this.frontend.settings.minimizeServerMsgs ? "short_text" : "notes";
-            this.list = [];
-            this.refresh();
+          this.frontend.settings.minimizeServerMsgs = !this.frontend.settings.minimizeServerMsgs;
+          this.frontend.settings.save();
+          this.actions[2][1] = this.frontend.settings.minimizeServerMsgs ? "short_text" : "notes";
+          this.list = [];
+          this.refresh();
         }
       ],
 
@@ -90,15 +90,15 @@ export class FrontendChatPanel extends FrontendBasicPanel {
 
   async refresh() {
     if (this.paused)
-        return;
+      return;
     await super.refresh();
     if (this.autoscroll)
-        this.elBody.scrollTop = this.elBody.scrollHeight;
+      this.elBody.scrollTop = this.elBody.scrollHeight;
   }
 
   async update() {
     if (this.paused)
-        return;
+      return;
     this.data = await fetch(this.ep + "?count=100").then(r => r.json());
     // @ts-ignore
     this.list = this.data.map(data => this.createEntry(data.Text, data.Color, data));
@@ -234,7 +234,7 @@ export class FrontendChatPanel extends FrontendBasicPanel {
     this.list.push(this.createEntry(text, color, data));
     if (this.list.length > 100) {
       this.list = this.list.slice(-100);
-      }
+    }
     if (this.paused)
       return;
     this.render(null);

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -50,7 +50,7 @@ export class FrontendChatPanel extends FrontendBasicPanel {
       ],
 
       [
-          "Shorten Server messages", this.frontend.settings.minimizeServerMsgs ? "short_text" : "notes",
+        "Shorten Server messages", this.frontend.settings.minimizeServerMsgs ? "short_text" : "notes",
         () => {
           this.frontend.settings.minimizeServerMsgs = !this.frontend.settings.minimizeServerMsgs;
           this.frontend.settings.save();

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -32,6 +32,35 @@ export class FrontendChatPanel extends FrontendBasicPanel {
     /** @type {[string, string, () => void][]} */
     this.actions = [
       [
+        "Pause", "pause",
+        () => {
+            this.paused = !this.paused;
+            this.render();
+            if (!this.paused)
+                this.refresh();
+        }
+      ],
+
+      [
+        "Auto-scroll", "vertical_align_bottom",
+        () => {
+            this.autoscroll = !this.autoscroll;
+            this.refresh();
+        }
+      ],
+
+      [
+          "Shorten Server messages", this.frontend.settings.minimizeServerMsgs ? "short_text" : "notes",
+        () => {
+            this.frontend.settings.minimizeServerMsgs = !this.frontend.settings.minimizeServerMsgs;
+            this.frontend.settings.save();
+            this.actions[2][1] = this.frontend.settings.minimizeServerMsgs ? "short_text" : "notes";
+            this.list = [];
+            this.refresh();
+        }
+      ],
+
+      [
         "Fetch Log", "history",
         () => {
           this.refresh();
@@ -51,16 +80,25 @@ export class FrontendChatPanel extends FrontendBasicPanel {
     this.list = [];
     /** @type {ChatData[]} */
     this.data = [];
+    /** @type boolean */
+    this.paused = false;
+    /** @type boolean */
+    this.autoscroll = true;
 
     frontend.sync.register("chat", data => this.log(data.Text, data.Color, data));
   }
 
   async refresh() {
+    if (this.paused)
+        return;
     await super.refresh();
-    this.elBody.scrollTop = this.elBody.scrollHeight;
+    if (this.autoscroll)
+        this.elBody.scrollTop = this.elBody.scrollHeight;
   }
 
   async update() {
+    if (this.paused)
+        return;
     this.data = await fetch(this.ep + "?count=100").then(r => r.json());
     // @ts-ignore
     this.list = this.data.map(data => this.createEntry(data.Text, data.Color, data));
@@ -74,6 +112,21 @@ export class FrontendChatPanel extends FrontendBasicPanel {
       ${el => this.renderBody(el)}
       ${el => this.renderInput(el)}
     </div>`;
+  }
+
+  renderHeader(el) {
+    el = super.renderHeader(el);
+    let actionBtns = this.elHeader.getElementsByTagName("button");
+    actionBtns[0].classList.toggle("button-fade", !this.paused);
+    actionBtns[1].classList.toggle("button-fade", !this.autoscroll);
+    if (this.paused) {
+      actionBtns[1].setAttribute("disabled", "true");
+      actionBtns[2].setAttribute("disabled", "true");
+    } else {
+      actionBtns[1].removeAttribute("disabled");
+      actionBtns[2].removeAttribute("disabled");
+    }
+    return el;
   }
 
   renderInput(el) {
@@ -163,6 +216,10 @@ export class FrontendChatPanel extends FrontendBasicPanel {
       else
         el.classList.remove("hidden");
 
+      if (this.frontend.settings.minimizeServerMsgs)
+        if (data.Targeted && color && (color.toLowerCase() == "#9e24f5" || color.toLowerCase() == "#e39dcc"))
+          el.classList.add("minimized");
+
       return el;
     };
   }
@@ -177,9 +234,12 @@ export class FrontendChatPanel extends FrontendBasicPanel {
     this.list.push(this.createEntry(text, color, data));
     if (this.list.length > 100) {
       this.list = this.list.slice(-100);
-    }
+      }
+    if (this.paused)
+      return;
     this.render(null);
-    this.elBody.scrollTop = this.elBody.scrollHeight;
+    if (this.autoscroll)
+      this.elBody.scrollTop = this.elBody.scrollHeight;
   }
 
 }


### PR DESCRIPTION
Adding some quality-of-life features to the control panel's chat panel:
![image](https://user-images.githubusercontent.com/1682215/151636254-365ea4d8-55d1-48fa-ac11-62d4311edefb.png)

I fiddled around with some stuff in `settingsCP()` in `dialog.js` because some checkbox & label attributes aren't fully confgurable with `mdcrd.checkbox` at the moment.