### PR TITLE
Misc rendering fixes (Fonts.Load / List.First / BlurRT null)

### DIFF
--- a/CelesteNet.Client/CelesteNetClientFontMono.cs
+++ b/CelesteNet.Client/CelesteNetClientFontMono.cs
@@ -23,7 +23,7 @@ namespace Celeste.Mod.CelesteNet.Client {
     public static class CelesteNetClientFontMono {
 
         // English is always loaded. Other language fonts must be loaded manually. Load only loads once.
-        public static PixelFont Font => Fonts.Load(Dialog.Languages["japanese"].FontFace);
+        public static PixelFont Font => Fonts.Get(Dialog.Languages["japanese"].FontFace);
 
         public static PixelFontSize FontSize => Font.Get(BaseSize);
 

--- a/CelesteNet.Client/CelesteNetClientFontMono.cs
+++ b/CelesteNet.Client/CelesteNetClientFontMono.cs
@@ -22,8 +22,10 @@ namespace Celeste.Mod.CelesteNet.Client {
     // Copy of ActiveFont that always uses a font with monospace Latin characters / Arabic numbers.
     public static class CelesteNetClientFontMono {
 
-        // English is always loaded. Other language fonts must be loaded manually. Load only loads once.
-        public static PixelFont Font => Fonts.Get(Dialog.Languages["japanese"].FontFace);
+        private static string FontFace => Dialog.Languages["japanese"].FontFace;
+
+        // English is always loaded. Other language fonts must be loaded manually. Only load once.
+        public static PixelFont Font => Fonts.Get(FontFace) ?? Fonts.Load(FontFace);
 
         public static PixelFontSize FontSize => Font.Get(BaseSize);
 

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -473,7 +473,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
                 // Don't rebuild the entire list
                 // Try to find the player's blob
-                BlobPlayer playerBlob = (BlobPlayer) List?.First(b => b is BlobPlayer pb && pb.Player == info.Player);
+                BlobPlayer playerBlob = (BlobPlayer) List?.FirstOrDefault(b => b is BlobPlayer pb && pb.Player == info.Player);
                 if (playerBlob == null)
                     return;
 

--- a/CelesteNet.Client/Components/CelesteNetRenderHelperComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetRenderHelperComponent.cs
@@ -56,11 +56,15 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
             Rectangle rect = new(xi, yi, wi, hi);
 
-            MDraw.SpriteBatch.Draw(
-                BlurRT,
-                rect, rect,
-                Color.White * Math.Min(1f, color.A / 255f * 2f)
-            );
+            if (BlurRT != null) {
+                MDraw.SpriteBatch.Draw(
+                    BlurRT,
+                    rect, rect,
+                    Color.White * Math.Min(1f, color.A / 255f * 2f)
+                );
+            } else {
+                Logger.LogDetailed("cnet-rndrhlp", "BlurRT is null!");
+            }
 
             MDraw.Rect(xi, yi, wi, hi, color);
         }


### PR DESCRIPTION
Three unrelated fixes for things that may lead to Exceptions somewhere down the line.

1. The `Fonts.Load` call happens whenever the PixelFont is used e.g. for rendering calls, and causes Everest to run Emoji.Fill() which itself can cause Exceptions under rare circumstances if the Lists being iterated within that function get updated by other calls while it iterates. That itself should be fixed in Everest's Emoji.cs most likely.

**Edit:** Somehow I had overlooked the fact that Fonts.Load does need to be called once here where in the other ClientFont it doesn't, since English is always loaded and Japanese isn't. I don't know why I thought that was a working fix before. I made it into a `Fonts.Get(FontFace) ?? Fonts.Load(FontFace)` now, so that way it only calls `Fonts.Load` once and afterwards only the `Fonts.Get` should be doing the work there.

2. The `First(...)` on the player list component's List should've been a `FirstOrDefault(...)` since I expected the expression to return null under various circumstances, and the list somehow being empty (can actually be triggered by spamming reconnects) shouldn't cause an Exception/crash.

3. The check against `BlurRT != null` is because I had occasional Exceptions/crashes there, I think with the "persistent" components or right when components are recreated upon reconnect.