### PR TITLE
Non-Interactive players respond with "Release Me" to any Grab packet.

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -219,6 +219,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     ghost == null)
                     return;
 
+                if (Settings.Interactions != state.Interactive && ghost == GrabbedBy)
+                    SendReleaseMe();
+
                 Session session = Session;
                 if (session != null && (state.SID != session.Area.SID || state.Mode != session.Area.Mode || state.Level == LevelDebugMap)) {
                     ghost.RunOnUpdate(ghost => ghost.NameTag.Name = "");
@@ -447,8 +450,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public void Handle(CelesteNetConnection con, DataPlayerGrabPlayer grab) {
             Player player = Player;
-            if (Engine.Scene is not Level level || level.Paused || player == null || !Settings.Interactions)
+            if (player != null && !Settings.Interactions && (grab.Player.ID == Client.PlayerInfo.ID || grab.Grabbing.ID == Client.PlayerInfo.ID))
                 goto Release;
+
+            if (Engine.Scene is not Level level || level.Paused || player == null || !Settings.Interactions)
+                return;
 
             if (grab.Player.ID != Client.PlayerInfo.ID && grab.Grabbing.ID == Client.PlayerInfo.ID) {
                 if (GrabCooldown > 0f) {


### PR DESCRIPTION
Fix non-interactive players always responding with 'release me' packets when receiving any grab packet.

Currently it's basically
```c#
        public void Handle(CelesteNetConnection con, DataPlayerGrabPlayer grab) {
            if (... !Settings.Interactions)
                  goto Release;
            [...]

            Release:
            SendReleaseMe(); //has no further checks, just sends a DataPlayerGrabPlayer response
        }
```