### PR TITLE
Control Panel chat log less cluttered

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
@@ -47,7 +47,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 Format = "png";
                 PathVirtual = $"emoji/{ID}";
                 Emoji.Register(ID, GFX.Misc["whiteCube"]);
-                //Logger.Log(LogLevel.DEV, "emoji", $"Calling Fill from new NetEmojiAsset(): {ID}");
                 Emoji.Fill(CelesteNetClientFont.Font);
             }
 
@@ -55,7 +54,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 Buffer.Dispose();
                 if (!Pending) {
                     Emoji.Register(ID, GFX.Misc["whiteCube"]);
-                    //Logger.Log(LogLevel.DEV, "emoji", $"Calling Fill from Dispose(): {ID}");
                     Emoji.Fill(CelesteNetClientFont.Font);
                 }
             }
@@ -126,7 +124,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                             MTexture tex = new(vtex);
                             Content.Registered.Add(asset.ID);
                             Emoji.Register(asset.ID, tex);
-                            //Logger.Log(LogLevel.DEV, "emoji", $"Calling Fill from Handle(..., DataNetEmoji): {netemoji.ID}");
                             Emoji.Fill(CelesteNetClientFont.Font);
                         });
                     } catch (ObjectDisposedException) {

--- a/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
@@ -47,6 +47,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 Format = "png";
                 PathVirtual = $"emoji/{ID}";
                 Emoji.Register(ID, GFX.Misc["whiteCube"]);
+                //Logger.Log(LogLevel.DEV, "emoji", $"Calling Fill from new NetEmojiAsset(): {ID}");
                 Emoji.Fill(CelesteNetClientFont.Font);
             }
 
@@ -54,6 +55,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 Buffer.Dispose();
                 if (!Pending) {
                     Emoji.Register(ID, GFX.Misc["whiteCube"]);
+                    //Logger.Log(LogLevel.DEV, "emoji", $"Calling Fill from Dispose(): {ID}");
                     Emoji.Fill(CelesteNetClientFont.Font);
                 }
             }
@@ -124,6 +126,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                             MTexture tex = new(vtex);
                             Content.Registered.Add(asset.ID);
                             Emoji.Register(asset.ID, tex);
+                            //Logger.Log(LogLevel.DEV, "emoji", $"Calling Fill from Handle(..., DataNetEmoji): {netemoji.ID}");
                             Emoji.Fill(CelesteNetClientFont.Font);
                         });
                     } catch (ObjectDisposedException) {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -14,8 +14,10 @@ const mdc = window["mdc"]; // mdc
 @typedef {{
   ID: number,
   PlayerID: number,
-  Targeted: boolean,
+  Targets: number[] | null,
   Color: string,
+  DateTime: number,
+  Tag: string,
   Text: string
 }} ChatData
  */
@@ -99,10 +101,21 @@ export class FrontendChatPanel extends FrontendBasicPanel {
   async update() {
     if (this.paused)
       return;
-    this.data = await fetch(this.ep + "?count=100").then(r => r.json());
+    this.data = await fetch(this.ep + "?count=100&detailed=true").then(r => r.json());
     // @ts-ignore
-    this.list = this.data.map(data => this.createEntry(data.Text, data.Color, data));
+    this.list = this.data.filter(data => !this.dropExtraChannelChats(data)).map(data => this.createEntry(data.Text, data.Color, data));
   }
+
+    /**
+     * @param {ChatData} [data]
+     * @returns boolean
+     */
+    dropExtraChannelChats(data) {
+      // Conditions to DROP this message:
+      // it's sent in a channel, AND it has Targets AND the player sending it is not such a Target.
+      // this predicate is meant to drop all the repeat channel messages that are akin to whispering each recipient individually
+      return data.Tag.startsWith("channel ") && data.Targets && data.Targets.indexOf(data.PlayerID) == -1
+    }
 
   render(el) {
     return this.el = rd$(el || this.el)`
@@ -176,13 +189,10 @@ export class FrontendChatPanel extends FrontendBasicPanel {
    */
   createEntry(text, color, data) {
     return el => {
-      el = mdcrd.list.item(text)(el);
-      if (color && color.toLowerCase() !== "#ffffff")
-        el.style.color = color;
-      else
-        el.style.color = "#000000";
-
       let opts = [];
+      let name = "";
+        let targets = [];
+        let tag = "";
 
       if (data) {
         opts = [
@@ -192,32 +202,57 @@ export class FrontendChatPanel extends FrontendBasicPanel {
             Color: "#ee2233",
             Text: "*deleted*"
           }) ]
-        ];
-
-        if (data.PlayerID && data.PlayerID !== this.frontend.MAX_INT) {
-          const player = FrontendPlayersPanel["instance"].data.find(p => p.ID == data.PlayerID);
-          // TODO: Rerender el on missing player only once! Otherwise render -> refresh -> render -> refresh...
-          if (!player)
-            FrontendPlayersPanel["instance"].refresh();
-          const name = player && player.FullName || ("#" + data.PlayerID);
-
-          opts = [
-            ...opts,
-            [ "error_outline", `Kick ${name}`, () => this.frontend.dialog.kick(data.PlayerID) ],
-            [ "gavel", `Ban ${name}`, () => this.frontend.dialog.ban(player && player.UID, player && player.ConnectionUID) ]
           ];
-        }
+
+          if (data.Tag)
+              tag = "[" + data.Tag + "] ";
+
+          if (data.PlayerID) {
+              if (data.PlayerID !== this.frontend.MAX_INT) {
+                  const player = FrontendPlayersPanel["instance"].data.find(p => p.ID == data.PlayerID);
+                  // TODO: Rerender el on missing player only once! Otherwise render -> refresh -> render -> refresh...
+                  if (!player)
+                      FrontendPlayersPanel["instance"].refresh();
+                  name = player && player.FullName || ("#" + data.PlayerID);
+
+                  opts = [
+                      ...opts,
+                      ["error_outline", `Kick ${name}`, () => this.frontend.dialog.kick(data.PlayerID)],
+                      ["gavel", `Ban ${name}`, () => this.frontend.dialog.ban(player && player.UID, player && player.ConnectionUID)]
+                  ];
+              } else {
+                  name = " ** SERVER ** ";
+              }
+          }
+
+          if (data.Targets && data.Targets.length > 0 && !data.Tag.startsWith("channel ")) {
+              for (var targetID in data.Targets) {
+                  const player = FrontendPlayersPanel["instance"].data.find(p => p.ID == targetID);
+                  if (player)
+                      targets.push(player && player.FullName || ("#" + targetID));
+              }
+          }
+
       }
+
+        let chatText = `[${new Date(data.DateTime).toLocaleTimeString("de-DE")}] ${tag}${name}${(targets.length > 0 ? " @" + targets.join(",") : "")}:${(data.Text.indexOf('\n') != -1 ? "\n" : " ")}${data.Text}`;
+
+      el = mdcrd.list.item(chatText)(el);
+      if (color && color.toLowerCase() !== "#ffffff")
+        el.style.color = color;
+      else
+        el.style.color = "#000000";
+
 
       this.frontend.dom.setContext(el, ...opts);
 
-      if (data.Targeted && !this.frontend.settings.sensitive)
+      if (data.Targets && !this.frontend.settings.sensitive)
         el.classList.add("hidden");
       else
         el.classList.remove("hidden");
 
       if (this.frontend.settings.minimizeServerMsgs)
-        if (data.Targeted && color && (color.toLowerCase() == "#9e24f5" || color.toLowerCase() == "#e39dcc"))
+        if (data.Targets && color && (color.toLowerCase() == "#9e24f5" || color.toLowerCase() == "#e39dcc"))
           el.classList.add("minimized");
 
       return el;
@@ -230,6 +265,8 @@ export class FrontendChatPanel extends FrontendBasicPanel {
    * @param {ChatData} [data]
    */
   log(text, color, data) {
+    if (this.dropExtraChannelChats(data))
+      return;
     // @ts-ignore
     this.list.push(this.createEntry(text, color, data));
     if (this.list.length > 100) {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -258,6 +258,8 @@ export class FrontendChatPanel extends FrontendBasicPanel {
       if (this.frontend.settings.minimizeServerMsgs)
         if (data.Targets && color && (color.toLowerCase() == "#9e24f5" || color.toLowerCase() == "#e39dcc"))
           el.classList.add("minimized");
+        else
+          el.classList.remove("minimized");
 
       return el;
     };

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -117,7 +117,7 @@ export class FrontendChatPanel extends FrontendBasicPanel {
       let isRedundant = data.Tag.startsWith("channel ") && data.Targets && data.Targets.indexOf(data.PlayerID) == -1;
 
       // not 100% sure if we want to drop command responses too, all they show us/the client that the command was received?...
-      isRedundant ||= data.Text.startsWith("/") && data.Targets && data.Targets.indexOf(data.PlayerID) > -1;
+      isRedundant ||= data.Text.startsWith("/") && !data.Targets;
       return isRedundant;
     }
 

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -144,12 +144,12 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         }
 
         private bool OnChatReceive(ChatModule chat, DataChat msg) {
-            BroadcastCMD(msg.Targets != null, "chat", msg.ToFrontendChat());
+            BroadcastCMD(msg.Targets != null, "chat", msg.ToDetailedFrontendChat());
             return true;
         }
 
         private void OnForceSend(ChatModule chat, DataChat msg) {
-            BroadcastCMD(msg.Targets != null, "chat", msg.ToFrontendChat());
+            BroadcastCMD(msg.Targets != null, "chat", msg.ToDetailedFrontendChat());
         }
 
         private string? GetContentType(string path) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatEdit.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatEdit.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 msg.Text = (string) input.Text;
 
             chat.ForceSend(msg);
-            return msg.ToFrontendChat();
+            return msg.ToDetailedFrontendChat();
         }
     }
 }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatX.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatX.cs
@@ -26,7 +26,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             string colorStr = (string?) input.Color ?? "";
             Color color = !colorStr.IsNullOrEmpty() ? Calc.HexToColor(colorStr) : chat.Settings.ColorBroadcast;
 
-            return chat.Broadcast(text, tag, color).ToFrontendChat();
+            return chat.Broadcast(text, tag, color).ToDetailedFrontendChat();
         }
     }
 }


### PR DESCRIPTION
This is very much just a bandaid fix, but currently reading the chat log is so tedious when there's a lot of channel chat and whispers going on.

I feel like it's something we need to properly deal with... just kind of rewrite some parts of chat so that it's easier to distinguish channel chats from other chat messages and such. 

Right now every message to a channel chat is basically a broadcast whisper, and if there's `N` other players in the channel, the message shows up `N+3` times... Even an actual `/w` is currently 4 entries in the chat log!

![image](https://user-images.githubusercontent.com/1682215/186280261-16f521c9-e43f-451c-94c3-31540f92799e.png)

Example of before/after.

One problem in this is that I went and used `ToDetailedFrontendChat()` instead of `ToFrontendChat()` from `CelesteNet.Server.Control.FrontendUtils` a bunch now. Which means some of the "assembly work" of making the chat message string that `ToFrontendChat` actually did (which lost some meta data like recipients list...) is now duplicated in `chat.js`.

`ToFrontendChat()` used...
```c#
msg.Date.ToLocalTime().ToLongTimeString()
```
... on the server, so I used ...
```js
new Date(data.DateTime).toLocaleTimeString("de-DE")
```
...in `chat.js`. 
When it was server-side it's pretty much also always been showing this timezone in the server chat log, right? Could potentially start using the browser's local time now.