### PR TITLE
Prevent chat from opening if keyboard is used for text entry dialog

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -180,9 +180,12 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             _Time += Engine.RawDeltaTime;
             _TimeSinceCursorMove += Engine.RawDeltaTime;
 
+            Overworld overworld = Engine.Scene as Overworld;
             bool isRebinding = Engine.Scene == null ||
                 Engine.Scene.Entities.FindFirst<KeyboardConfigUI>() != null ||
-                Engine.Scene.Entities.FindFirst<ButtonConfigUI>() != null;
+                Engine.Scene.Entities.FindFirst<ButtonConfigUI>() != null ||
+                ((overworld?.Current ?? overworld?.Next) is OuiFileNaming naming && naming.UseKeyboardInput) ||
+                ((overworld?.Current ?? overworld?.Next) is UI.OuiModOptionString stringInput && stringInput.UseKeyboardInput);
 
             if (!(Engine.Scene?.Paused ?? true) || isRebinding) {
                 string typing = Typing;


### PR DESCRIPTION
Prevent chat from opening if keyboard is used for text entry dialogues like OuiFileNaming and OuiModOptionString.

So using the letter T to name your Save file won't make you send the remaining letters to Celestenet chat. 🙂 

(I took this snippet from Everest's [Patches/MountainRenderer.cs](https://github.com/RedFlames/Everest/blob/3d519e2d9ee59257ee525a9479d45c3298b7ef2b/Celeste.Mod.mm/Patches/MountainRenderer.cs#L46) where spacebar is used to trigger freecam, but checks against these dialogues too.)