### PR TITLE
Emote timeskip fixes for Prologue and EH heart

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetEmoteComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmoteComponent.cs
@@ -150,6 +150,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         private void OnHeartGemCollect(On.Celeste.HeartGem.orig_Collect orig, HeartGem self, Player player) {
             orig(self, player);
             Wheel?.TimeRateSkip.Add(self.IsFake ? "EmptySpaceHeart" : "HeartGem");
+            if (self.IsFake && Wheel != null)
+                Wheel.timeSkipForcedDelay = 10f;
         }
 
         private void OnHeartGemEndCutscene(On.Celeste.HeartGem.orig_EndCutscene orig, HeartGem self) {

--- a/CelesteNet.Client/Components/CelesteNetEmoteComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmoteComponent.cs
@@ -103,7 +103,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             if (Wheel == null)
                 level.Add(Wheel = new(Player));
 
-            if (!level.Paused && Settings.EmoteWheel && !Player.Dead) {
+            // TimeRate check is for Prologue Dash prompt freeze
+            if (!level.Paused && Settings.EmoteWheel && !Player.Dead && Engine.TimeRate > 0.05f) {
                 Wheel.Shown = CelesteNetClientModule.Instance.JoystickEmoteWheel.Value.LengthSquared() >= 0.36f;
                 int selected = Wheel.Selected;
                 if (Wheel.Shown && selected != -1 && CelesteNetClientModule.Instance.ButtonEmoteSend.Pressed) {
@@ -148,7 +149,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         private void OnHeartGemCollect(On.Celeste.HeartGem.orig_Collect orig, HeartGem self, Player player) {
             orig(self, player);
-            Wheel?.TimeRateSkip.Add("HeartGem");
+            Wheel?.TimeRateSkip.Add(self.IsFake ? "EmptySpaceHeart" : "HeartGem");
         }
 
         private void OnHeartGemEndCutscene(On.Celeste.HeartGem.orig_EndCutscene orig, HeartGem self) {

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -774,7 +774,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 level.Add(PlayerNameTag = new(Player, Client.PlayerInfo.DisplayName));
             }
             PlayerNameTag.Alpha = Settings.ShowOwnName ? 1f : 0f;
-            PlayerNameTag.Name = $"{Engine.TimeRate} {level.Frozen}  {level.FrozenOrPaused} {(level.Tracker == null ? "no tr" : Context?.Get<CelesteNetEmoteComponent>() is CelesteNetEmoteComponent e ? e.Wheel?.TimeRateSkip.FirstOrDefault() : "no eco")} {level.InCutscene} {Player.StateMachine.State}";
         }
 
         public override void Tick() {

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -774,6 +774,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 level.Add(PlayerNameTag = new(Player, Client.PlayerInfo.DisplayName));
             }
             PlayerNameTag.Alpha = Settings.ShowOwnName ? 1f : 0f;
+            PlayerNameTag.Name = $"{Engine.TimeRate} {level.Frozen}  {level.FrozenOrPaused} {(level.Tracker == null ? "no tr" : Context?.Get<CelesteNetEmoteComponent>() is CelesteNetEmoteComponent e ? e.Wheel?.TimeRateSkip.FirstOrDefault() : "no eco")} {level.InCutscene} {Player.StateMachine.State}";
         }
 
         public override void Tick() {

--- a/CelesteNet.Client/Entities/GhostEmoteWheel.cs
+++ b/CelesteNet.Client/Entities/GhostEmoteWheel.cs
@@ -1,11 +1,7 @@
-﻿using Celeste.Mod.CelesteNet.Client.Components;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Monocle;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Celeste.Mod.CelesteNet.Client.Entities {
     // TODO: This is taken mostly as is from GhostNet and can be improved.
@@ -23,6 +19,7 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         protected bool timeRateSet = false;
 
         public HashSet<string> TimeRateSkip = new();
+        public float timeSkipForcedDelay = -1f;
         public bool ForceSetTimeRate;
 
         public float Angle = 0f;
@@ -49,8 +46,15 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         public override void Update() {
             // Update only runs while the level is "alive" (scene not paused or frozen).
 
-            if (TimeRateSkip.Contains("EmptySpaceHeart") && Tracking?.Scene.Tracker.GetEntity<Player>() is Player p && p.StateMachine.State != Player.StDummy)
+            if (TimeRateSkip.Contains("EmptySpaceHeart") &&
+                timeSkipForcedDelay <= 0f &&
+                Engine.Scene is Level l && !l.InCutscene) {
                 TimeRateSkip.Remove("EmptySpaceHeart");
+            }
+
+            if (timeSkipForcedDelay >= 0f) {
+                timeSkipForcedDelay -= Engine.RawDeltaTime;
+            }
 
             // TimeRate check is for Prologue Dash prompt freeze
             if (Engine.TimeRate > 0.05f && (TimeRateSkip.Count == 0 || ForceSetTimeRate)) {

--- a/CelesteNet.Client/Entities/GhostEmoteWheel.cs
+++ b/CelesteNet.Client/Entities/GhostEmoteWheel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Celeste.Mod.CelesteNet.Client.Components;
+using Microsoft.Xna.Framework;
 using Monocle;
 using System;
 using System.Collections.Generic;
@@ -48,7 +49,11 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         public override void Update() {
             // Update only runs while the level is "alive" (scene not paused or frozen).
 
-            if (TimeRateSkip.Count == 0 || ForceSetTimeRate) {
+            if (TimeRateSkip.Contains("EmptySpaceHeart") && Tracking?.Scene.Tracker.GetEntity<Player>() is Player p && p.StateMachine.State != Player.StDummy)
+                TimeRateSkip.Remove("EmptySpaceHeart");
+
+            // TimeRate check is for Prologue Dash prompt freeze
+            if (Engine.TimeRate > 0.05f && (TimeRateSkip.Count == 0 || ForceSetTimeRate)) {
                 if (Shown && !timeRateSet) {
                     Engine.TimeRate = 0.25f;
                     timeRateSet = true;


### PR DESCRIPTION
A fix for https://github.com/0x0ade/CelesteNet/issues/36

For the Prologue time freeze being accidentally unfrozen by the emote wheel, I introduced checks if `Engine.TimeRate > 0.05f` and such, so that the emote wheel won't reset the game's time rate when it's set to `0.0f` (or close to that, just to be safe with the floats...).

For the EH heart I'm honestly not sure if it even needs any of the special handling since it's just a cutscene and not like grabbing a B- or C-Side heart (which I assume is what the "HeartGem" TimeRateSkip thing is for? Idk what exactly it "protects" against.)

But since the EH heart only triggers OnHeartGemCollect and not OnHeartGemEndCutscene I had to introduce some extra logic into `GhostEmoteWheel.Update()` to get the TimeSkip removed at an appropriate time.