### PR TITLE
Check if guest name is valid user key and avoid leaking it to clients

### DIFF
--- a/CelesteNet.Server/ConPlus/HandshakerRole.cs
+++ b/CelesteNet.Server/ConPlus/HandshakerRole.cs
@@ -126,7 +126,7 @@ namespace Celeste.Mod.CelesteNet.Server {
                     tokenSrc.CancelAfter(TeapotTimeout);
                     tokenSrc.Token.Register(() => sock.Close());
                     try {
-                        (IConnectionFeature[] conFeatures, string playerUID, string playerName, CelesteNetClientOptions clientOptions)? teapotRes =
+                        (IConnectionFeature[], string, string, CelesteNetClientOptions)? teapotRes =
                             await TeapotHandshake(
                                 sock, conToken, settings,
                                 ConPlusTCPUDPConnection.GetConnectionUID(remoteEP)
@@ -366,6 +366,12 @@ Who wants some tea?"
                 if (playerUID != null && Server.UserData.TryLoad(playerUID, out BasicUserInfo info))
                     playerName = info.Name;
                 else
+                    return string.Format(Server.Settings.MessageInvalidKey, nameKey);
+            } else if (nameKey.Length == 16 && nameKey.All("0123456789abcdefABCDEF".Contains) && (playerUID = Server.UserData.GetUID(nameKey)) != null) {
+                // this is for people who entered 16 hex-digits and probably forgot the # and we don't want to leak their key
+                if (Server.UserData.TryLoad(playerUID, out BasicUserInfo info)) {
+                    playerName = info.Name;
+                } else
                     return string.Format(Server.Settings.MessageInvalidKey, nameKey);
             } else if (!Server.Settings.AuthOnly) {
                 playerName = nameKey;


### PR DESCRIPTION
Feature description:

Every now and then a new player manually enters their key into the Name/Key field forgetting the `#` and ends up leaking their key straight to all other connected players. This is not good. 
I built a basic check into the Server that will check if the "Name" is in fact a 16 digit hex value and attempt to interpret it as a key. If successful, the connection acts as if the player had the `#` before the key all along.

I also thought about implementing some hack into the client that would allow it to detect this particular scenario as well and prefix its setting with the "#" but without sending this extra information to the client, I'm not sure how feasible it would be. 
E.g. in `CelesteNetClient.Handle(...)` for `DataPlayerInfo` it does take the very first player info received as its own player information, but this doesn't send back the key that the server identified the client as, and I didn't want to play guessing games comparing `PlayerInfo.Name` to `Settings.Name` since these would also differ when you become `Guest#2` and such... would only want to commit the "#" prefix to the Settings if we're sure it should be there.

So I might make a client fix that will involve a new `DataType` for Server-invoked Client `Settings` updates? Could be useful to have this sort of thing for more than just updating Name/Key in the client.

_PS: I'm no expert on this but those variables scoped to the try/catch in line 129 seemed to just be shadowing variables from the scope above and weren't needed at all since it's just outlining the structure of the return value here? Some kind of tuple, idk the exact name. I just yoinked those and it still seems to work._