### PR TITLE
Prevent chat component NREs when Client is null

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -142,6 +142,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         public void Handle(CelesteNetConnection con, DataChat msg) {
+            if (Client == null)
+                return;
+
             lock (Log) {
                 if (msg.Player?.ID == Client.PlayerInfo?.ID) {
                     foreach (DataChat pending in Pending.Values) {
@@ -176,6 +179,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public override void Update(GameTime gameTime) {
             base.Update(gameTime);
+
+            if (Client == null) {
+                Active = false;
+                return;
+            }
 
             _Time += Engine.RawDeltaTime;
             _TimeSinceCursorMove += Engine.RawDeltaTime;


### PR DESCRIPTION
This is in response to this error report from someone on Discord:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Celeste.Mod.CelesteNet.Client.Components.CelesteNetChatComponent.Send(String text) in D:\...\CelesteNet\CelesteNet.Client\Components\CelesteNetChatComponent.cs:line 131
   at Celeste.Mod.CelesteNet.Client.Components.CelesteNetChatComponent.Update(GameTime gameTime) in D:\...\CelesteNet\CelesteNet.Client\Components\CelesteNetChatComponent.cs:line 219
```
And looking at https://github.com/0x0ade/CelesteNet/blob/9c1c404180d97c648c0d6d61be59d288b95c8c22/CelesteNet.Client/Components/CelesteNetChatComponent.cs#L125-L135 (or rather 133 there based on "current" release build sources from around January) the only thing I can think of being null there is Client, from Context being null'd by a disconnect but Update running at that exact moment?

Some other Update() methods are guarded against Client being null so I figured it'd be best if this one was too. Never seen this as an issue with Handle() methods and there'd be a lot of them that aren't properly protected against these kinds of NRE situations, so perhaps not touching those.