### PR TITLE
Resend graphics when hair length change detected

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -269,7 +269,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             if (ghost == null) {
                 if (!Client.Data.TryGetBoundRef<DataPlayerInfo, DataPlayerGraphics>(frame.Player, out DataPlayerGraphics graphics) || graphics == null)
                     return;
-                Logger.Log("HAIR", $"Creating ghost for {frame.Player.Name}: {graphics.HairCount}");
                 ghost = CreateGhost(level, frame.Player, graphics);
             }
 
@@ -738,11 +737,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 }
             }
 
-            if (Player != null && Player.Sprite != null && SentHairLength != Player.Sprite.HairCount) {
-                Logger.Log("HAIR", $"Resending graphics because: {SentHairLength} != {Player.Sprite.HairCount}");
+            if (Player != null && Player.Sprite != null && SentHairLength != Player.Sprite.HairCount)
                 SendGraphics();
-            }
-
 
             bool idle = level.FrozenOrPaused || level.Overlay != null;
             if (WasIdle != idle) {
@@ -782,8 +778,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 level.Add(PlayerNameTag = new(Player, Client.PlayerInfo.DisplayName));
             }
             PlayerNameTag.Alpha = Settings.ShowOwnName ? 1f : 0f;
-            if (Player.Hair != null)
-                PlayerNameTag.Name = $"{Player.Hair.SimulateMotion} {Player.Hair.Active} {Player.Sprite.Active} {Player.Active}";
         }
 
         public override void Tick() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1682215/191747176-d01d9d8f-c764-432b-9c18-061b519d16e3.png)

Somehow I got one of my clones to actually send hair, but 99% of the time, when respawning, the player graphics get sent without proper modded hair. I don't know if it used to get sent properly and something changed in how Hyperline and others update hair, but most of the time you only see other players with 5 hair segments or even 4, somehow. (PlayerSprite or whichever class has HairCount defaults it to 4, idk why)

So I simply added a variable to track the hair length when sending out a graphics update, and later if the actual player hair length is different, resend graphics.

One other fix I threw in here is this vs. this:
![image](https://user-images.githubusercontent.com/1682215/191747895-c7c24cf5-328a-4448-a8f2-2d81b72354e3.png)
![image](https://user-images.githubusercontent.com/1682215/191747927-dff578b9-57c5-42bb-ac94-efed7a71fe0e.png)
(Don't mind the True True True... I unsuccessfully looked for a variable that would _really_ tell me if hair should be updated or not.)

Seems like the hair's `SimulateMotion` bool isn't enough to know if the hair should be moving or not, so I tacked on an `&& !state.Idle` so that at least when someone pauses their game, their hair pauses for others too :)