### PR TITLE
Rebuild PlayerList less often when DataPlayerState received

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -404,6 +404,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 blob.Location.TitleColor = Color.Lerp(area?.TitleBaseColor ?? Color.White, DefaultLevelColor, 0.5f);
                 blob.Location.AccentColor = Color.Lerp(area?.TitleAccentColor ?? Color.White, DefaultLevelColor, 0.8f);
 
+                blob.Location.SID = state.SID;
                 blob.Location.Name = chapter;
                 blob.Location.Side = ((char) ('A' + (int) state.Mode)).ToString();
                 blob.Location.Level = state.Level;
@@ -463,7 +464,20 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         public void Handle(CelesteNetConnection con, DataPlayerState state) {
-            RunOnMainThread(() => RebuildList());
+            RunOnMainThread(() => {
+                // Don't rebuild the entire list
+                // Try to find the player's blob
+                BlobPlayer playerBlob = (BlobPlayer) List?.FirstOrDefault(b => b is BlobPlayer pb && pb.Player == state.Player);
+                if (playerBlob == null || playerBlob.Location.SID.IsNullOrEmpty() || playerBlob.Location.SID != state.SID) {
+                    RebuildList();
+                    return;
+                }
+
+                // just update blob state, since SID hasn't changed
+                GetState(playerBlob, state);
+                playerBlob.Generate();
+            });
+
         }
 
         public void Handle(CelesteNetConnection con, DataConnectionInfo info) {
@@ -754,6 +768,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             public string Level = "";
             private float LevelWidthScaled;
             public string Icon = "";
+
+            public string SID = "";
 
             public bool IsRandomizer;
 

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -468,7 +468,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 // Don't rebuild the entire list
                 // Try to find the player's blob
                 BlobPlayer playerBlob = (BlobPlayer) List?.FirstOrDefault(b => b is BlobPlayer pb && pb.Player == state.Player);
-                if (playerBlob == null || playerBlob.Location.SID.IsNullOrEmpty() || playerBlob.Location.SID != state.SID) {
+                if (playerBlob == null || playerBlob.Location.SID.IsNullOrEmpty() || playerBlob.Location.SID != state.SID || playerBlob.Location.Level.Length < state.Level.Length - 1) {
                     RebuildList();
                     return;
                 }


### PR DESCRIPTION
I noticed `Handle(CelesteNetConnection con, DataPlayerState state)` in the PlayerList unconditionally rebuilds the player list and I found that rather strange, doesn't this mean when in the same Level or Screen as someone else, you will essentially be rebuilding your player list every frame or tick or at least as often as someone else is sending state info?...

I made it so that it only updates the BlobPlayer's state with `GetState(...)` unless the location info of the player has drastically changed. Keeping track of the SID within BlobLocation now just for comparison's sake, and I might be needing it in another patch soon.