### PR TITLE
Chat QoL: Tab completions - Server-side only - (new branch)

### DIFF
--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDBan.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDBan.cs
@@ -8,11 +8,14 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDBan : ChatCMD {
 
         public override string Args => "<user> <text>";
+
+        public override CompletionType Completion => CompletionType.Player;
 
         public override string Info => "Ban a player from the server with a given reason.";
 

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDBan.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDBan.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDBan : ChatCMD {

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDJoin : ChatCMDChannel {

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
@@ -15,6 +15,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
 
         public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<ChatCMDChannel>().ID}";
 
+        public override bool InternalAliasing => true;
+
     }
 
     public class ChatCMDChannel : ChatCMD {

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDJoin : ChatCMDChannel {
@@ -19,6 +20,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDChannel : ChatCMD {
 
         public override string Args => "[page] | [channel]";
+
+        public override CompletionType Completion => CompletionType.Channel;
 
         public override string Info => "Switch to a different channel.";
         public override string Help =>

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDEmote.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDEmote.cs
@@ -20,6 +20,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
 
         public override string Args => "<text> | i:<img> | p:<img> | g:<img>";
 
+        public override CompletionType Completion => CompletionType.Emote;
+
         public override string Info => "Send an emote appearing over your player.";
         public override string Help =>
 @"Send an emote appearing over your player.

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDHelp.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDHelp.cs
@@ -7,11 +7,14 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDHelp : ChatCMD {
 
         public override string Args => "[page] | [command]";
+
+        public override CompletionType Completion => CompletionType.Command;
 
         public override string Info => "Get help on how to use commands.";
 

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDHelp.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDHelp.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDHelp : ChatCMD {

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDKick.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDKick.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDKick : ChatCMD {

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDKick.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDKick.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDKick : ChatCMD {
@@ -15,6 +16,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public override string Args => "<user>";
 
         public override string Info => "Kick a player from the server.";
+
+        public override CompletionType Completion => CompletionType.Player;
 
         public override bool MustAuth => true;
 

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDTP.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDTP.cs
@@ -9,11 +9,14 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDTP : ChatCMD {
 
         public override string Args => "<player>";
+
+        public override CompletionType Completion => CompletionType.Player;
 
         public override string Info => "Teleport to another player.";
 

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDTP.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDTP.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDTP : ChatCMD {

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDWhisper.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDWhisper.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDW : ChatCMDWhisper {
@@ -19,6 +20,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDWhisper : ChatCMD {
 
         public override string Args => "<user> <text>";
+
+        public override CompletionType Completion => CompletionType.Player;
 
         public override string Info => "Send a whisper to someone else or toggle whispers.";
 

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDWhisper.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDWhisper.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCMDW : ChatCMDWhisper {

--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -42,8 +42,15 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
                 ByType.TryGetValue(cmd.GetType().BaseType, out ChatCMD? aliasTo);
 
                 if (aliasTo != null)
-                    Logger.Log(LogLevel.VVV, "chatcmds", $"Command: {cmd.ID.ToLowerInvariant()} is alias of {aliasTo.ID.ToLowerInvariant()}");
-                DataAll.List[i++] = new CommandInfo() {ID = cmd.ID, Auth = cmd.MustAuth, AuthExec = cmd.MustAuthExec, FirstArg = cmd.Completion, AliasTo = aliasTo?.ID.ToLowerInvariant() ?? "" };
+                    Logger.Log(LogLevel.VVV, "chatcmds", $"Command: {cmd.ID.ToLowerInvariant()} is {(cmd.InternalAliasing ? "internal alias" : "alias")} of {aliasTo.ID.ToLowerInvariant()}");
+
+                DataAll.List[i++] = new CommandInfo() {
+                                        ID = cmd.ID,
+                                        Auth = cmd.MustAuth,
+                                        AuthExec = cmd.MustAuthExec,
+                                        FirstArg = cmd.Completion,
+                                        AliasTo = cmd.InternalAliasing ? "" : aliasTo?.ID.ToLowerInvariant() ?? ""
+                                    };
             }
 
             All = All.OrderBy(cmd => cmd.HelpOrder).ToList();
@@ -85,6 +92,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public virtual bool MustAuthExec => false;
 
         public virtual CompletionType Completion => CompletionType.None;
+
+        public virtual bool InternalAliasing => false;
 
         public virtual void Init(ChatModule chat) {
             Chat = chat;

--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
+using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCommands : IDisposable {
@@ -25,17 +26,17 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
                 ChatCMD? cmd = (ChatCMD?) Activator.CreateInstance(type);
                 if (cmd == null)
                     throw new Exception($"Cannot create instance of CMD {type.FullName}");
-                Logger.Log(LogLevel.VVV, "chatcmds", $"Found command: {cmd.ID.ToLowerInvariant()} ({type.FullName})");
+                Logger.Log(LogLevel.VVV, "chatcmds", $"Found command: {cmd.ID.ToLowerInvariant()} ({type.FullName}, {cmd.Completion})");
                 All.Add(cmd);
                 ByID[cmd.ID.ToLowerInvariant()] = cmd;
                 ByType[type] = cmd;
             }
-            DataAll.List = new DataCommandList.Command[All.Count];
+            DataAll.List = new CommandInfo[All.Count];
 
             int i = 0;
             foreach (ChatCMD cmd in All) {
                 cmd.Init(chat);
-                DataAll.List[i++] = new DataCommandList.Command() {ID = cmd.ID, Auth = cmd.MustAuth, AuthExec = cmd.MustAuthExec };
+                DataAll.List[i++] = new CommandInfo() {ID = cmd.ID, Auth = cmd.MustAuth, AuthExec = cmd.MustAuthExec, FirstArg = cmd.Completion };
             }
 
             All = All.OrderBy(cmd => cmd.HelpOrder).ToList();
@@ -75,6 +76,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
 
         public virtual bool MustAuth => false;
         public virtual bool MustAuthExec => false;
+
+        public virtual CompletionType Completion => CompletionType.None;
 
         public virtual void Init(ChatModule chat) {
             Chat = chat;

--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
-using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatCommands : IDisposable {

--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -36,7 +36,14 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
             int i = 0;
             foreach (ChatCMD cmd in All) {
                 cmd.Init(chat);
-                DataAll.List[i++] = new CommandInfo() {ID = cmd.ID, Auth = cmd.MustAuth, AuthExec = cmd.MustAuthExec, FirstArg = cmd.Completion };
+
+                // check if **base** type is an existing command in ByType, which means this cmd is an alias
+                // N.B. the base type ChatCMD itself is abstract and shouldn't be in ByType; see above
+                ByType.TryGetValue(cmd.GetType().BaseType, out ChatCMD? aliasTo);
+
+                if (aliasTo != null)
+                    Logger.Log(LogLevel.VVV, "chatcmds", $"Command: {cmd.ID.ToLowerInvariant()} is alias of {aliasTo.ID.ToLowerInvariant()}");
+                DataAll.List[i++] = new CommandInfo() {ID = cmd.ID, Auth = cmd.MustAuth, AuthExec = cmd.MustAuthExec, FirstArg = cmd.Completion, AliasTo = aliasTo?.ID.ToLowerInvariant() ?? "" };
             }
 
             All = All.OrderBy(cmd => cmd.HelpOrder).ToList();

--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -35,7 +35,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
             int i = 0;
             foreach (ChatCMD cmd in All) {
                 cmd.Init(chat);
-                DataAll.List[i++] = new DataCommandList.Command() {ID = cmd.ID};
+                DataAll.List[i++] = new DataCommandList.Command() {ID = cmd.ID, Auth = cmd.MustAuth, AuthExec = cmd.MustAuthExec };
             }
 
             All = All.OrderBy(cmd => cmd.HelpOrder).ToList();

--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -15,6 +15,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public readonly List<ChatCMD> All = new();
         public readonly Dictionary<string, ChatCMD> ByID = new();
         public readonly Dictionary<Type, ChatCMD> ByType = new();
+        public readonly DataCommandList DataAll = new DataCommandList();
 
         public ChatCommands(ChatModule chat) {
             foreach (Type type in CelesteNetUtils.GetTypes()) {
@@ -29,9 +30,13 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
                 ByID[cmd.ID.ToLowerInvariant()] = cmd;
                 ByType[type] = cmd;
             }
+            DataAll.List = new DataCommandList.Command[All.Count];
 
-            foreach (ChatCMD cmd in All)
+            int i = 0;
+            foreach (ChatCMD cmd in All) {
                 cmd.Init(chat);
+                DataAll.List[i++] = new DataCommandList.Command() {ID = cmd.ID};
+            }
 
             All = All.OrderBy(cmd => cmd.HelpOrder).ToList();
         }

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -58,6 +58,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
                     Broadcast(Settings.MessageGreeting.InjectSingleValue("player", session.PlayerInfo?.DisplayName ?? "???"));
                 SendTo(session, Settings.MessageMOTD);
             }
+            session.Con.SendCommandList(Commands.DataAll);
+
             SpamContext spam = session.Set(this, new SpamContext(this));
             spam.OnSpam += (msg, timeout) => {
                 msg.Target = session.PlayerInfo;

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -58,7 +58,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
                     Broadcast(Settings.MessageGreeting.InjectSingleValue("player", session.PlayerInfo?.DisplayName ?? "???"));
                 SendTo(session, Settings.MessageMOTD);
             }
-            session.Con.SendCommandList(Commands.DataAll);
+            session.SendCommandList(Commands.DataAll);
 
             SpamContext spam = session.Set(this, new SpamContext(this));
             spam.OnSpam += (msg, timeout) => {

--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -38,6 +38,7 @@ namespace Celeste.Mod.CelesteNet.Server {
         private readonly object RequestNextIDLock = new();
         private uint RequestNextID = 0;
 
+        public DataCommandList[] Commands = Dummy<DataCommandList>.EmptyArray;
         internal CelesteNetPlayerSession(CelesteNetServer server, CelesteNetConnection con, uint sesId, string uid, string name, CelesteNetClientOptions clientOptions) {
             Server = server;
             Con = con;
@@ -286,6 +287,13 @@ namespace Celeste.Mod.CelesteNet.Server {
             }
 
             return true;
+        }
+
+        public void SendCommandList(DataCommandList commands) {
+            if (commands == null || commands.List.Length == 0) {
+                return;
+            }
+            Con.Send(commands);
         }
 
         public event Action<CelesteNetPlayerSession, DataPlayerInfo?>? OnEnd;

--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -38,7 +38,6 @@ namespace Celeste.Mod.CelesteNet.Server {
         private readonly object RequestNextIDLock = new();
         private uint RequestNextID = 0;
 
-        public DataCommandList Commands = new();
         internal CelesteNetPlayerSession(CelesteNetServer server, CelesteNetConnection con, uint sesId, string uid, string name, CelesteNetClientOptions clientOptions) {
             Server = server;
             Con = con;
@@ -294,6 +293,9 @@ namespace Celeste.Mod.CelesteNet.Server {
                 return;
             }
 
+            // I almost made this a member variable of this class, but there's no point rn because it's only sent once at session start
+            DataCommandList filteredCommands = new();
+
             bool auth = false;
             bool authExec = false;
             if (!(UID?.IsNullOrEmpty() ?? true) && Server.UserData.TryLoad(UID, out BasicUserInfo info)) {
@@ -301,9 +303,9 @@ namespace Celeste.Mod.CelesteNet.Server {
                 authExec = info.Tags.Contains(BasicUserInfo.TAG_AUTH_EXEC);
             }
 
-            Commands.List = commands.List.Where(cmd => (!cmd.Auth || auth) && (!cmd.AuthExec || authExec)).ToArray();
+            filteredCommands.List = commands.List.Where(cmd => (!cmd.Auth || auth) && (!cmd.AuthExec || authExec)).ToArray();
 
-            Con.Send(Commands);
+            Con.Send(filteredCommands);
         }
 
         public event Action<CelesteNetPlayerSession, DataPlayerInfo?>? OnEnd;

--- a/CelesteNet.Shared/CommandInfo.cs
+++ b/CelesteNet.Shared/CommandInfo.cs
@@ -1,19 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Monocle;
-
-namespace Celeste.Mod.CelesteNet {
+﻿namespace Celeste.Mod.CelesteNet {
 
     public class CommandInfo {
         public string ID = "";

--- a/CelesteNet.Shared/CommandInfo.cs
+++ b/CelesteNet.Shared/CommandInfo.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Celeste.Mod.CelesteNet.DataTypes;
+using Celeste.Mod.Helpers;
+using Monocle;
+
+namespace Celeste.Mod.CelesteNet {
+
+    public class CommandInfo {
+        public string ID = "";
+        public string AliasTo = "";
+        public bool Auth = false;
+        public bool AuthExec = false;
+        public CompletionType FirstArg = CompletionType.None;
+    }
+
+    public enum CompletionType : byte {
+        None = 0,
+        Command = 1,
+        Channel = 2,
+        Player = 3
+    }
+}

--- a/CelesteNet.Shared/CommandInfo.cs
+++ b/CelesteNet.Shared/CommandInfo.cs
@@ -12,6 +12,7 @@
         None = 0,
         Command = 1,
         Channel = 2,
-        Player = 3
+        Player = 3,
+        Emote = 4
     }
 }

--- a/CelesteNet.Shared/DataTypes/DataCommandList.cs
+++ b/CelesteNet.Shared/DataTypes/DataCommandList.cs
@@ -24,6 +24,7 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
             for (int ci = 0; ci < List.Length; ci++) {
                 CommandInfo c = List[ci] = new();
                 c.ID = reader.ReadNetString();
+                c.AliasTo = reader.ReadNetString();
                 c.Auth = reader.ReadBoolean();
                 c.AuthExec = reader.ReadBoolean();
                 c.FirstArg = (CompletionType) reader.ReadByte();
@@ -34,6 +35,7 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
             writer.Write((uint) List.Length);
             foreach (CommandInfo c in List) {
                 writer.WriteNetString(c.ID);
+                writer.WriteNetString(c.AliasTo);
                 writer.Write(c.Auth);
                 writer.Write(c.AuthExec);
                 writer.Write((byte) c.FirstArg);
@@ -42,6 +44,7 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
 
         public class CommandInfo {
             public string ID = "";
+            public string AliasTo = "";
             public bool Auth = false;
             public bool AuthExec = false;
             public CompletionType FirstArg = CompletionType.None;

--- a/CelesteNet.Shared/DataTypes/DataCommandList.cs
+++ b/CelesteNet.Shared/DataTypes/DataCommandList.cs
@@ -42,20 +42,5 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
             }
         }
 
-        public class CommandInfo {
-            public string ID = "";
-            public string AliasTo = "";
-            public bool Auth = false;
-            public bool AuthExec = false;
-            public CompletionType FirstArg = CompletionType.None;
-        }
-
-        public enum CompletionType : byte {
-            None = 0,
-            Command = 1,
-            Channel = 2,
-            Player = 3
-        }
-
     }
 }

--- a/CelesteNet.Shared/DataTypes/DataCommandList.cs
+++ b/CelesteNet.Shared/DataTypes/DataCommandList.cs
@@ -36,6 +36,8 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
 
         public class Command {
             public string ID = "";
+            public bool Auth = false;
+            public bool AuthExec = false;
         }
 
     }

--- a/CelesteNet.Shared/DataTypes/DataCommandList.cs
+++ b/CelesteNet.Shared/DataTypes/DataCommandList.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.CelesteNet.DataTypes {
+    public class DataCommandList : DataType<DataCommandList> {
+
+        static DataCommandList() {
+            DataID = "commandList";
+        }
+
+        public Command[] List = Dummy<Command>.EmptyArray;
+
+        protected override void Read(CelesteNetBinaryReader reader) {
+            List = new Command[reader.ReadUInt32()];
+            for (int ci = 0; ci < List.Length; ci++) {
+                Command c = List[ci] = new();
+                c.ID = reader.ReadNetString();
+            }
+        }
+
+        protected override void Write(CelesteNetBinaryWriter writer) {
+            writer.Write((uint) List.Length);
+            foreach (Command c in List) {
+                writer.WriteNetString(c.ID);
+            }
+        }
+
+        public class Command {
+            public string ID = "";
+        }
+
+    }
+}

--- a/CelesteNet.Shared/DataTypes/DataCommandList.cs
+++ b/CelesteNet.Shared/DataTypes/DataCommandList.cs
@@ -17,27 +17,41 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
             DataID = "commandList";
         }
 
-        public Command[] List = Dummy<Command>.EmptyArray;
+        public CommandInfo[] List = Dummy<CommandInfo>.EmptyArray;
 
         protected override void Read(CelesteNetBinaryReader reader) {
-            List = new Command[reader.ReadUInt32()];
+            List = new CommandInfo[reader.ReadUInt32()];
             for (int ci = 0; ci < List.Length; ci++) {
-                Command c = List[ci] = new();
+                CommandInfo c = List[ci] = new();
                 c.ID = reader.ReadNetString();
+                c.Auth = reader.ReadBoolean();
+                c.AuthExec = reader.ReadBoolean();
+                c.FirstArg = (CompletionType) reader.ReadByte();
             }
         }
 
         protected override void Write(CelesteNetBinaryWriter writer) {
             writer.Write((uint) List.Length);
-            foreach (Command c in List) {
+            foreach (CommandInfo c in List) {
                 writer.WriteNetString(c.ID);
+                writer.Write(c.Auth);
+                writer.Write(c.AuthExec);
+                writer.Write((byte) c.FirstArg);
             }
         }
 
-        public class Command {
+        public class CommandInfo {
             public string ID = "";
             public bool Auth = false;
             public bool AuthExec = false;
+            public CompletionType FirstArg = CompletionType.None;
+        }
+
+        public enum CompletionType : byte {
+            None = 0,
+            Command = 1,
+            Channel = 2,
+            Player = 3
         }
 
     }


### PR DESCRIPTION
## This is only the **server-side stuff** necessary for tab completion.
(This is cherry-picked from https://github.com/0x0ade/CelesteNet/pull/26)
<sub>(And I accidentally merged that entire branch into the other "server-only" PR so this is a do-over...)</sub>

**The server now has some basic info about:**
 - what sort of first argument a command expects
 - which commands are aliased to which
 - the auth tags required and it'll be smart about sending the list (regular players won't get `/kick` as a completion option)

**... and it can send this info to the client.**

---

If a client doesn't understand the `DataCommandList` DataType it will just be ignored and current clients run as usual. 

If we merge & release this first, dev clients could properly evalute https://github.com/0x0ade/CelesteNet/pull/26 on the live server.

---

#### Things to note:

Nothing :)

~~The `using static Celeste.Mod.CelesteNet.DataTypes.DataCommandList;` is probably a bit of a sin?... I threw that into every ChatCMD... class just so that I could use the `enum CompletionType` values there...~~