### PR TITLE
Chat QoL: scrolling only

### DIFF
--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -105,6 +105,8 @@ namespace Celeste.Mod.CelesteNet.Client {
         [SettingRange(4, 16)]
         public int ChatLogLength { get; set; } = 8;
 
+        [SettingRange(1, 5)]
+        public int ChatScrollSpeed { get; set; } = 2;
         public CelesteNetChatComponent.ChatScrollFade ChatScrollFade { get; set; } = CelesteNetChatComponent.ChatScrollFade.Low;
 
         public const int UISizeMin = 1;

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -105,6 +105,8 @@ namespace Celeste.Mod.CelesteNet.Client {
         [SettingRange(4, 16)]
         public int ChatLogLength { get; set; } = 8;
 
+        public CelesteNetChatComponent.ChatScrollFade ChatScrollFade { get; set; } = CelesteNetChatComponent.ChatScrollFade.Low;
+
         public const int UISizeMin = 1;
         public const int UISizeMax = 4;
         [SettingRange(UISizeMin, UISizeMax)]

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -107,7 +107,7 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         [SettingRange(1, 5)]
         public int ChatScrollSpeed { get; set; } = 2;
-        public CelesteNetChatComponent.ChatScrollFade ChatScrollFade { get; set; } = CelesteNetChatComponent.ChatScrollFade.Low;
+        public CelesteNetChatComponent.ChatScrollFade ChatScrollFading { get; set; } = CelesteNetChatComponent.ChatScrollFade.Fast;
 
         public const int UISizeMin = 1;
         public const int UISizeMax = 4;

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -572,12 +572,12 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                         offs -= CelesteNetClientFont.Measure(".").X / 2f * scale;
 
                         CelesteNetClientFont.Draw(
-                               "|",
-                               new(50f * scale + offs, UI_HEIGHT - 110f * scale),
-                               Vector2.Zero,
-                               fontScale * new Vector2(.5f, 1.2f),
-                               Color.White * 0.6f
-                           );
+                            "|",
+                            new(50f * scale + offs, UI_HEIGHT - 110f * scale),
+                            Vector2.Zero,
+                            fontScale * new Vector2(.5f, 1.2f),
+                            Color.White * 0.6f
+                        );
                     }
                 }
 
@@ -585,24 +585,28 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     skippedMsgCount += Log.Count - ScrolledFromIndex;
 
                 if (Typing.Length > 0 && skippedMsgCount > 0) {
-                    CelesteNetClientFont.Draw(
+                    SetPromptMessage(
                         $"({skippedMsgCount} newer message{(skippedMsgCount > 1 ? "s" : "")} off-screen!)",
-                        new(200f * scale + CelesteNetClientFont.Measure(text).X * scale, UI_HEIGHT - 105f * scale),
-                        Vector2.Zero,
-                        fontScale,
                         Color.OrangeRed
                     );
                 } else if (ScrolledFromIndex > 0 && ScrolledFromIndex < Log.Count) {
-                    CelesteNetClientFont.Draw(
+                    SetPromptMessage(
                         $"({Log.Count - ScrolledFromIndex} new message{(Log.Count - ScrolledFromIndex > 1 ? "s" : "")} since you scrolled up!)",
-                        new(200f * scale + CelesteNetClientFont.Measure(text).X * scale, UI_HEIGHT - 105f * scale),
-                        Vector2.Zero,
-                        fontScale,
                         Color.GreenYellow
                     );
                 }
+
+                CelesteNetClientFont.Draw(
+                    PromptMessage,
+                    new(200f * scale + CelesteNetClientFont.Measure(text).X * scale, UI_HEIGHT - 105f * scale),
+                    Vector2.Zero,
+                    fontScale,
+                    PromptMessageColor
+                );
+
             }
         }
+
 
         protected override void Dispose(bool disposing) {
             if (Active)

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -235,7 +235,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             } else if (Active) {
                 Engine.Commands.Open = false;
 
-                ScrolledDistance = Math.Max(0f, ScrolledDistance + (MInput.Keyboard.CurrentState[Keys.PageUp] - MInput.Keyboard.CurrentState[Keys.PageDown]) * 3f * (CelesteNetClientSettings.UISizeMax - Settings.UISize)/2f);
+                ScrolledDistance = Math.Max(0f, ScrolledDistance + (MInput.Keyboard.CurrentState[Keys.PageUp] - MInput.Keyboard.CurrentState[Keys.PageDown]) * 2f * Settings.ChatScrollSpeed);
                 if (ScrolledDistance < 10f) {
                     ScrolledFromIndex = Log.Count;
                 }
@@ -503,6 +503,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                         ScrolledDistance -= scrollOffset;
                     }
 
+                    RenderPositionY = y;
+
                     if (Active) {
                         float x = 25f * scale;
                         y -= 2 * ScrollPromptSize.Y * scale;
@@ -550,8 +552,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     fontScale,
                     PromptMessageColor
                 );
-
-                RenderPositionY = y;
             }
         }
 

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -45,12 +45,12 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                                 GFX.Gui["controls/directions/0x-1"].Width + GFX.Gui["controls/keyboard/PageUp"].Width,
                                 Math.Max(GFX.Gui["controls/directions/0x-1"].Height, GFX.Gui["controls/keyboard/PageUp"].Height)
                             );
-        public float ScrollFade => (int) Settings.ChatScrollFade / 2f;
+        public float ScrollFade => (int) Settings.ChatScrollFading / 2f;
 
         public enum ChatScrollFade {
             None = 0,
-            Low = 1,
-            High = 2
+            Fast = 1,
+            Smooth = 2
         }
 
         public List<string> Repeat = new() {

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -17,6 +17,12 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         protected float _Time;
 
         public float Scale => Settings.UIScale;
+        protected int ScrolledFromIndex = 0;
+        protected float ScrolledDistance = 0f;
+        protected int skippedMsgCount = 0;
+
+        public string PromptMessage = "";
+        public Color PromptMessageColor = Color.White;
 
         public float? RenderPositionY { get; private set; } = null;
 
@@ -33,6 +39,18 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             All,
             Special,
             Off
+        }
+
+        protected Vector2 ScrollPromptSize = new Vector2(
+                                GFX.Gui["controls/directions/0x-1"].Width + GFX.Gui["controls/keyboard/PageUp"].Width,
+                                Math.Max(GFX.Gui["controls/directions/0x-1"].Height, GFX.Gui["controls/keyboard/PageUp"].Height)
+                            );
+        public float ScrollFade => (int) Settings.ChatScrollFade / 2f;
+
+        public enum ChatScrollFade {
+            None = 0,
+            Low = 1,
+            High = 2
         }
 
         public List<string> Repeat = new() {
@@ -89,6 +107,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             set {
                 if (_Active == value)
                     return;
+                ScrolledDistance = 0f;
+                ScrolledFromIndex = 0;
+                SetPromptMessage("");
 
                 if (value) {
                     _SceneWasPaused = Engine.Scene.Paused;
@@ -100,7 +121,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     _RepeatIndex = 0;
                     _Time = 0;
                     TextInput.OnInput += OnTextInput;
-
                 } else {
                     Typing = "";
                     CursorIndex = 0;
@@ -206,6 +226,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
             } else if (Active) {
                 Engine.Commands.Open = false;
+
+                ScrolledDistance = Math.Max(0f, ScrolledDistance + (MInput.Keyboard.CurrentState[Keys.PageUp] - MInput.Keyboard.CurrentState[Keys.PageDown]) * 3f * (CelesteNetClientSettings.UISizeMax - Settings.UISize)/2f);
+                if (ScrolledDistance < 10f) {
+                    ScrolledFromIndex = Log.Count;
+                }
 
                 _ControlHeld = MInput.Keyboard.Check(Keys.LeftControl) || MInput.Keyboard.Check(Keys.RightControl);
 
@@ -357,6 +382,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             }
         }
 
+        public void SetPromptMessage(string msg, Color? color = null) {
+            PromptMessage = msg;
+            PromptMessageColor = color ?? Color.White;
+        }
+
         protected override void Render(GameTime gameTime, bool toBuffer) {
             float scale = Scale;
             Vector2 fontScale = Vector2.One * scale;
@@ -370,17 +400,19 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     _ => Log,
                 };
 
-                int count = log.Count;
-                if (count > 0) {
+                if (log.Count > 0) {
                     DateTime now = DateTime.UtcNow;
 
                     float y = UI_HEIGHT - 50f * scale;
                     if (Active)
                         y -= 105f * scale;
 
+                    float scrollOffset = ScrolledDistance;
                     float logLength = Settings.ChatLogLength;
-                    for (int i = 0; i < count && i < logLength; i++) {
-                        DataChat msg = log[count - 1 - i];
+                    int renderedCount = 0;
+                    skippedMsgCount = 0;
+                    for (int i = 0; i < ScrolledFromIndex; i++) {
+                        DataChat msg = log[ScrolledFromIndex - 1 - i];
 
                         float alpha = 1f;
                         float delta = (float) (now - msg.ReceivedDate).TotalSeconds;
@@ -392,7 +424,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                         string time = msg.Date.ToLocalTime().ToLongTimeString();
 
                         string text = msg.ToString(true, false);
-                        logLength -= Math.Max(0, text.Count(c => c == '\n') - 1) * 0.75f;
 
                         int lineScaleTry = 0;
                         float lineScale = scale;
@@ -411,9 +442,33 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
                         float height = 50f * scale + size.Y;
 
+                        float cutoff = 0f;
+                        if (renderedCount == 0) {
+                            if (scrollOffset <= height) {
+                                y += scrollOffset;
+                                cutoff = scrollOffset;
+                                logLength += cutoff / height;
+                            } else {
+                                skippedMsgCount++;
+                                scrollOffset -= height;
+                                continue;
+                            }
+                        }
+                        int msgExtraLines = Math.Max(0, text.Count(c => c == '\n') - 1 - (int) (cutoff / sizeText.Y));
+                        renderedCount++;
+
                         y -= height;
 
-                        Context.RenderHelper.Rect(25f * scale, y, size.X + 50f * scale, height, Color.Black * 0.8f * alpha);
+                        // fade at the bottom
+                        alpha -= ScrollFade * cutoff / height;
+
+                        // fade at the top
+                        if (renderedCount >= logLength)
+                            alpha -= ScrollFade * Math.Max(0, renderedCount - logLength);
+                        
+                        logLength -= msgExtraLines * 0.75f * (cutoff > 0f ? 1f - cutoff / height : 1f);
+
+                        Context.RenderHelper.Rect(25f * scale, y, size.X + 50f * scale, height - cutoff, Color.Black * 0.8f * alpha);
                         CelesteNetClientFontMono.Draw(
                             time,
                             new(50f * scale, y + 20f * scale),
@@ -427,6 +482,48 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                             Vector2.Zero,
                             lineFontScale,
                             msg.Color * alpha * (msg.ID == uint.MaxValue ? 0.8f : 1f)
+                        );
+
+                        if (renderedCount >= logLength) {
+                            break;
+                        }
+                    }
+
+                    if (Active && renderedCount <= 1) {
+                        ScrolledDistance -= scrollOffset;
+                    }
+
+                    if (Active) {
+                        float x = 50f * scale;
+                        y -= 2 * ScrollPromptSize.Y * scale;
+
+                        Context.RenderHelper.Rect(x - 25f * scale, y, 50f * scale + ScrollPromptSize.X * scale, 2 * ScrollPromptSize.Y * scale, Color.Black * 0.8f);
+
+                        GFX.Gui["controls/keyboard/PageUp"].Draw(
+                            new(x, y),
+                            Vector2.Zero,
+                            MInput.Keyboard.CurrentState[Keys.PageUp] == KeyState.Down && renderedCount > 1 ? Color.Goldenrod : Color.White,
+                            scale
+                        );
+
+                        GFX.Gui["controls/keyboard/PageDown"].Draw(
+                            new(x, y + ScrollPromptSize.Y * scale),
+                            Vector2.Zero,
+                            MInput.Keyboard.CurrentState[Keys.PageDown] == KeyState.Down && ScrolledDistance > 0f ? Color.Goldenrod : Color.White,
+                            scale
+                        );
+
+                        GFX.Gui["controls/directions/0x-1"].Draw(
+                            new(x + GFX.Gui["controls/keyboard/PageUp"].Width * scale, y),
+                            Vector2.Zero,
+                            Color.White * (MInput.Keyboard.CurrentState[Keys.PageUp] == KeyState.Down && renderedCount > 1 ? 1f : .7f),
+                            scale
+                        );
+                        GFX.Gui["controls/directions/0x1"].Draw(
+                            new(x + GFX.Gui["controls/keyboard/PageDown"].Width * scale, y + ScrollPromptSize.Y * scale),
+                            Vector2.Zero,
+                            Color.White * (MInput.Keyboard.CurrentState[Keys.PageDown] == KeyState.Down && ScrolledDistance > 0f ? 1f : .7f),
+                            scale
                         );
                     }
 
@@ -479,6 +576,27 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                                Color.White * 0.6f
                            );
                     }
+                }
+
+                if (ScrolledFromIndex > 0)
+                    skippedMsgCount += Log.Count - ScrolledFromIndex;
+
+                if (Typing.Length > 0 && skippedMsgCount > 0) {
+                    CelesteNetClientFont.Draw(
+                        $"({skippedMsgCount} newer message{(skippedMsgCount > 1 ? "s" : "")} off-screen!)",
+                        new(200f * scale + CelesteNetClientFont.Measure(text).X * scale, UI_HEIGHT - 105f * scale),
+                        Vector2.Zero,
+                        fontScale,
+                        Color.OrangeRed
+                    );
+                } else if (ScrolledFromIndex > 0 && ScrolledFromIndex < Log.Count) {
+                    CelesteNetClientFont.Draw(
+                        $"({Log.Count - ScrolledFromIndex} new message{(Log.Count - ScrolledFromIndex > 1 ? "s" : "")} since you scrolled up!)",
+                        new(200f * scale + CelesteNetClientFont.Measure(text).X * scale, UI_HEIGHT - 105f * scale),
+                        Vector2.Zero,
+                        fontScale,
+                        Color.GreenYellow
+                    );
                 }
             }
         }

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -593,7 +593,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     // draw cursor at correct location, but move back half a "." width to not overlap following char
                     pos.X += CelesteNetClientFont.Measure(Typing.Substring(0, CursorIndex)).X * scale;
                     pos.X -= CelesteNetClientFont.Measure(".").X / 2f * scale;
-                    pos.Y += 5f * scale;
+                    pos.Y -= 5f * scale;
 
                     CelesteNetClientFont.Draw(
                         "|",

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -361,54 +361,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             float scale = Scale;
             Vector2 fontScale = Vector2.One * scale;
 
-            if (Active) {
-                Context.RenderHelper.Rect(25f * scale, UI_HEIGHT - 125f * scale, UI_WIDTH - 50f * scale, 100f * scale, Color.Black * 0.8f);
-
-                CelesteNetClientFont.Draw(
-                    ">",
-                    new(50f * scale, UI_HEIGHT - 105f * scale),
-                    Vector2.Zero,
-                    fontScale * new Vector2(0.5f, 1f),
-                    Color.White * 0.5f
-                );
-                float offs = CelesteNetClientFont.Measure(">").X * scale;
-
-                string text = Typing;
-                CelesteNetClientFont.Draw(
-                    text,
-                    new(50f * scale + offs, UI_HEIGHT - 105f * scale),
-                    Vector2.Zero,
-                    fontScale,
-                    Color.White
-                );
-
-                if (!Calc.BetweenInterval(_Time, 0.5f)) {
-
-                    if (CursorIndex == Typing.Length) {
-                        offs += CelesteNetClientFont.Measure(text).X * scale;
-                        CelesteNetClientFont.Draw(
-                            "_",
-                            new(50f * scale + offs, UI_HEIGHT - 105f * scale),
-                            Vector2.Zero,
-                            fontScale,
-                            Color.White * 0.5f
-                        );
-                    } else {
-                        // draw cursor at correct location, but move back half a "." width to not overlap following char
-                        offs += CelesteNetClientFont.Measure(Typing.Substring(0, CursorIndex)).X * scale;
-                        offs -= CelesteNetClientFont.Measure(".").X / 2f * scale;
-
-                        CelesteNetClientFont.Draw(
-                               "|",
-                               new(50f * scale + offs, UI_HEIGHT - 110f * scale),
-                               Vector2.Zero,
-                               fontScale * new Vector2(.5f, 1.2f),
-                               Color.White * 0.6f
-                           );
-                    }
-                }
-            }
-
             RenderPositionY = null;
 
             lock (Log) {
@@ -479,6 +431,54 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     }
 
                     RenderPositionY = y;
+                }
+            }
+
+            if (Active) {
+                Context.RenderHelper.Rect(25f * scale, UI_HEIGHT - 125f * scale, UI_WIDTH - 50f * scale, 100f * scale, Color.Black * 0.8f);
+
+                CelesteNetClientFont.Draw(
+                    ">",
+                    new(50f * scale, UI_HEIGHT - 105f * scale),
+                    Vector2.Zero,
+                    fontScale * new Vector2(0.5f, 1f),
+                    Color.White * 0.5f
+                );
+                float offs = CelesteNetClientFont.Measure(">").X * scale;
+
+                string text = Typing;
+                CelesteNetClientFont.Draw(
+                    text,
+                    new(50f * scale + offs, UI_HEIGHT - 105f * scale),
+                    Vector2.Zero,
+                    fontScale,
+                    Color.White
+                );
+
+                if (!Calc.BetweenInterval(_Time, 0.5f)) {
+
+                    if (CursorIndex == Typing.Length) {
+                        offs += CelesteNetClientFont.Measure(text).X * scale;
+                        CelesteNetClientFont.Draw(
+                            "_",
+                            new(50f * scale + offs, UI_HEIGHT - 105f * scale),
+                            Vector2.Zero,
+                            fontScale,
+                            Color.White * 0.5f
+                        );
+                    } else {
+                        // draw cursor at correct location, but move back half a "." width to not overlap following char
+                        offs += CelesteNetClientFont.Measure(Typing.Substring(0, CursorIndex)).X * scale;
+                        offs -= CelesteNetClientFont.Measure(".").X / 2f * scale;
+
+                        CelesteNetClientFont.Draw(
+                               "|",
+                               new(50f * scale + offs, UI_HEIGHT - 110f * scale),
+                               Vector2.Zero,
+                               fontScale * new Vector2(.5f, 1.2f),
+                               Color.White * 0.6f
+                           );
+                    }
                 }
             }
         }

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -140,6 +140,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
             UpdateOrder = 10000;
             DrawOrder = 10100;
+
+            Persistent = true;
         }
 
         public void Send(string text) {
@@ -411,8 +413,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     float logLength = Settings.ChatLogLength;
                     int renderedCount = 0;
                     skippedMsgCount = 0;
-                    for (int i = 0; i < ScrolledFromIndex; i++) {
-                        DataChat msg = log[ScrolledFromIndex - 1 - i];
+                    int count = ScrolledFromIndex > 0 ? ScrolledFromIndex : log.Count;
+                    for (int i = 0; i < count; i++) {
+                        DataChat msg = log[count - 1 - i];
 
                         float alpha = 1f;
                         float delta = (float) (now - msg.ReceivedDate).TotalSeconds;


### PR DESCRIPTION
This is nothing new, this is just more of me ripping my PR #26 into little chunks. :gladeline:

This is only the implementation of chat scrolling, nothing else.

 * It has settings for how fast it scrolls and for adjusting messages fading in & out at the edges of the chat log.

 * Scrolling is done with PageUp and PageDown and a prompt indicating this is rendered on the left above the chat.

* A little text message appears in the empty space in the chat input field when there's new messages that appeared after you started scrolling up; it clears when you scroll back to the bottom or close chat in some way.

That's about it!

Oh and instead of the merge **Compare** view here in the PR it might be easier to look at https://github.com/0x0ade/CelesteNet/commit/1eda6e13dc243112c5d3f7cf4f6c38ed1bcb00fb first because it moves a big chunk of code to a slightly different place, with no actual changes, just order of rendering operations.
And then read...
https://github.com/0x0ade/CelesteNet/compare/1eda6e13dc243112c5d3f7cf4f6c38ed1bcb00fb...RedFlames:chat-qol-scrolling-only?expand=1
...instead!