### PR TITLE
Separate UI scale settings

### DIFF
--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -190,7 +190,7 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         #region Helpers
 
-        private float CalcUIScale(int uisize) {
+        public float CalcUIScale(int uisize) {
             if (UIScaleOverride > 0f)
                 return UIScaleOverride;
             return uisize switch

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -107,19 +107,64 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public const int UISizeMin = 1;
         public const int UISizeMax = 4;
+        [SettingIgnore]
+        [YamlIgnore]
+        public int _UISize { get; private set; } = 2;
+        [SettingSubText("modoptions_celestenetclient_uisizehint")]
         [SettingRange(UISizeMin, UISizeMax)]
-        public int UISize { get; set; } = 2;
+        public int UISize {
+            get => _UISize;
+            set {
+                if (UISizeChatSlider != null && UISizePlayerListSlider != null && value != _UISize)
+                {
+                    UISizeChat = value;
+                    UISizePlayerList = value;
+
+                    if (value < _UISize)
+                    {
+                        UISizeChatSlider.LeftPressed();
+                        UISizePlayerListSlider.LeftPressed();
+                    }
+                    else
+                    {
+                        UISizeChatSlider.RightPressed();
+                        UISizePlayerListSlider.RightPressed();
+                    }
+
+                    UISizeChatSlider.Index = (value < UISizeMin ? UISizeMin : value > UISizeMax ? UISizeMax : value) - 1;
+                    UISizePlayerListSlider.Index = (value < UISizeMin ? UISizeMin : value > UISizeMax ? UISizeMax : value) - 1;
+                    UISizeChatSlider.OnValueChange.Invoke(value);
+                    UISizePlayerListSlider.OnValueChange.Invoke(value);
+                }
+                _UISize = value;
+            }
+        }
+
+        [SettingRange(UISizeMin, UISizeMax)]
+        public int UISizeChat { get; set; }
+
+        [SettingIgnore]
+        [YamlIgnore]
+        public TextMenu.Slider UISizeChatSlider { get; protected set; }
+
+        [SettingRange(UISizeMin, UISizeMax)]
+        public int UISizePlayerList { get; set; }
+
+        [SettingIgnore]
+        [YamlIgnore]
+        public TextMenu.Slider UISizePlayerListSlider { get; protected set; }
+
         [SettingIgnore]
         public float UIScaleOverride { get; set; } = 0f;
         [SettingIgnore]
         [YamlIgnore]
-        public float UIScale => UIScaleOverride > 0f ? UIScaleOverride : UISize switch {
-            1 => 0.25f,
-            2 => 0.4f,
-            3 => 0.6f,
-            4 => 0.75f,
-            _ => 0.5f + 0.5f * ((UISize - 1f) / (UISizeMax - 1f)),
-        };
+        public float UIScale => CalcUIScale(UISize);
+        [SettingIgnore]
+        [YamlIgnore]
+        public float UIScaleChat => CalcUIScale(UISizeChat);
+        [SettingIgnore]
+        [YamlIgnore]
+        public float UIScalePlayerList => CalcUIScale(UISizePlayerList);
 
         [SettingSubText("modoptions_celestenetclient_uiblurhint")]
         public CelesteNetRenderHelperComponent.BlurQuality UIBlur { get; set; } = CelesteNetRenderHelperComponent.BlurQuality.MEDIUM;
@@ -144,6 +189,19 @@ namespace Celeste.Mod.CelesteNet.Client {
 
 
         #region Helpers
+
+        private float CalcUIScale(int uisize) {
+            if (UIScaleOverride > 0f)
+                return UIScaleOverride;
+            return uisize switch
+            {
+                1 => 0.25f,
+                2 => 0.4f,
+                3 => 0.6f,
+                4 => 0.75f,
+                _ => 0.5f + 0.5f * ((UISize - 1f) / (UISizeMax - 1f)),
+            };
+        }
 
         [SettingIgnore]
         [YamlIgnore]
@@ -238,6 +296,21 @@ namespace Celeste.Mod.CelesteNet.Client {
             item.AddDescription(menu, "modoptions_celestenetclient_reloadhint".DialogClean());
         }
 
+        public void CreateUISizeChatEntry(TextMenu menu, bool inGame)
+        {
+            menu.Add(
+                (UISizeChatSlider = new TextMenu.Slider("modoptions_celestenetclient_uisizechat".DialogClean(), i => i.ToString(), UISizeMin, UISizeMax, UISizeChat))
+                            .Change(v => UISizeChat = v)
+            );
+        }
+
+        public void CreateUISizePlayerListEntry(TextMenu menu, bool inGame)
+        {
+            menu.Add(
+                (UISizePlayerListSlider = new TextMenu.Slider("modoptions_celestenetclient_uisizeplayerlist".DialogClean(), i => i.ToString(), UISizeMin, UISizeMax, UISizePlayerList))
+                            .Change(v => UISizePlayerList = v)
+            );
+        }
         #endregion
 
 

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -141,14 +141,14 @@ namespace Celeste.Mod.CelesteNet.Client {
         }
 
         [SettingRange(UISizeMin, UISizeMax)]
-        public int UISizeChat { get; set; }
+        public int UISizeChat { get; set; } = 2;
 
         [SettingIgnore]
         [YamlIgnore]
         public TextMenu.Slider UISizeChatSlider { get; protected set; }
 
         [SettingRange(UISizeMin, UISizeMax)]
-        public int UISizePlayerList { get; set; }
+        public int UISizePlayerList { get; set; } = 2;
 
         [SettingIgnore]
         [YamlIgnore]

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -131,8 +131,8 @@ namespace Celeste.Mod.CelesteNet.Client {
                         UISizePlayerListSlider.RightPressed();
                     }
 
-                    UISizeChatSlider.Index = (value < UISizeMin ? UISizeMin : value > UISizeMax ? UISizeMax : value) - 1;
-                    UISizePlayerListSlider.Index = (value < UISizeMin ? UISizeMin : value > UISizeMax ? UISizeMax : value) - 1;
+                    UISizeChatSlider.Index = Calc.Clamp(value, UISizeMin, UISizeMax) - 1;
+                    UISizePlayerListSlider.Index = UISizeChatSlider.Index;
                     UISizeChatSlider.OnValueChange.Invoke(value);
                     UISizePlayerListSlider.OnValueChange.Invoke(value);
                 }
@@ -140,15 +140,18 @@ namespace Celeste.Mod.CelesteNet.Client {
             }
         }
 
+        // these two are deliberately set to "illegal" values as their default,
+        // the reasoning being that players only had "UISize" set before this update
+        // and when these show up as zero, they can be set to the current UISize value accordingly
         [SettingRange(UISizeMin, UISizeMax)]
-        public int UISizeChat { get; set; } = 2;
+        public int UISizeChat { get; set; } = UISizeMin - 1;
 
         [SettingIgnore]
         [YamlIgnore]
         public TextMenu.Slider UISizeChatSlider { get; protected set; }
 
         [SettingRange(UISizeMin, UISizeMax)]
-        public int UISizePlayerList { get; set; } = 2;
+        public int UISizePlayerList { get; set; } = UISizeMin - 1;
 
         [SettingIgnore]
         [YamlIgnore]
@@ -298,6 +301,9 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public void CreateUISizeChatEntry(TextMenu menu, bool inGame)
         {
+            if (UISizeChat < UISizeMin || UISizeChat > UISizeMax)
+                UISizeChat = UISize;
+
             menu.Add(
                 (UISizeChatSlider = new TextMenu.Slider("modoptions_celestenetclient_uisizechat".DialogClean(), i => i.ToString(), UISizeMin, UISizeMax, UISizeChat))
                             .Change(v => UISizeChat = v)
@@ -306,6 +312,9 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public void CreateUISizePlayerListEntry(TextMenu menu, bool inGame)
         {
+            if (UISizePlayerList < UISizeMin || UISizePlayerList > UISizeMax)
+                UISizePlayerList = UISize;
+
             menu.Add(
                 (UISizePlayerListSlider = new TextMenu.Slider("modoptions_celestenetclient_uisizeplayerlist".DialogClean(), i => i.ToString(), UISizeMin, UISizeMax, UISizePlayerList))
                             .Change(v => UISizePlayerList = v)

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -16,7 +16,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         protected float _Time;
 
-        public float Scale => Settings.UIScale;
+        public float Scale => Settings.UIScaleChat;
 
         public float? RenderPositionY { get; private set; } = null;
 
@@ -100,7 +100,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     _RepeatIndex = 0;
                     _Time = 0;
                     TextInput.OnInput += OnTextInput;
-
                 } else {
                     Typing = "";
                     CursorIndex = 0;

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -15,8 +15,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public static event Action<BlobPlayer, DataPlayerState> OnGetState;
 
-        public float Scale => Settings.UIScalePlayerList;
-
         public readonly Color ColorCountHeader = Calc.HexToColor("FFFF77");
         public readonly Color ColorChannelHeader = Calc.HexToColor("DDDD88");
         public readonly Color ColorChannelHeaderOwn = Calc.HexToColor("FFFF77");
@@ -57,6 +55,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
          */
 
         public DataChannelList Channels;
+
+        private int UISize => Settings.UISizePlayerList;
+        private int LastUISize;
+
+        public float Scale => Settings.CalcUIScale(UISize);
 
         public ListModes ListMode => Settings.PlayerListMode;
         private ListModes LastListMode;
@@ -537,11 +540,13 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 LastLocationMode != LocationMode ||
                 LastShowPing != ShowPing ||
                 LastAllowSplit != AllowSplit ||
+                LastUISize != UISize ||
                 ShouldRebuild) {
                 LastListMode = ListMode;
                 LastLocationMode = LocationMode;
                 LastShowPing = ShowPing;
                 LastAllowSplit = AllowSplit;
+                LastUISize = UISize;
                 ShouldRebuild = false;
                 RebuildList();
             }

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -15,7 +15,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public static event Action<BlobPlayer, DataPlayerState> OnGetState;
 
-        public float Scale => Settings.UIScale;
+        public float Scale => Settings.UIScalePlayerList;
 
         public readonly Color ColorCountHeader = Calc.HexToColor("FFFF77");
         public readonly Color ColorChannelHeader = Calc.HexToColor("DDDD88");

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -31,8 +31,11 @@
 	MODOPTIONS_CELESTENETCLIENT_INTERACTIONSHINT= 		This only affects your ability to interact with others.
 	MODOPTIONS_CELESTENETCLIENT_ENTITIESHINT= 		Entities are keys, berries, Theo, jellyfish and other things.
 	MODOPTIONS_CELESTENETCLIENT_UISIZE= 			UI Size
+	MODOPTIONS_CELESTENETCLIENT_UISIZECHAT= 		UI Size: Chat
+	MODOPTIONS_CELESTENETCLIENT_UISIZEPLAYERLIST=	UI Size: Player List
 	MODOPTIONS_CELESTENETCLIENT_UIBLUR= 			UI Blur
 	MODOPTIONS_CELESTENETCLIENT_UIBLURHINT=			Lower the quality if you're experiencing lag.
+	MODOPTIONS_CELESTENETCLIENT_UISIZEHINT=			Changing this updates the UI Sizes "Player List" and "Chat" to this value.
 	MODOPTIONS_CELESTENETCLIENT_RELOAD= 			Reload Emotes
 	MODOPTIONS_CELESTENETCLIENT_RELOADHINT=			Open Saves/modsettings-CelesteNet.celeste in a text editor.
 	MODOPTIONS_CELESTENETCLIENT_RECOMMENDED= 		Install Recommended Mods


### PR DESCRIPTION
Note: This is also pulled from PR #26. Since this is a small changeset it'll be easier to merge and after this and #47, it'll leave #26 with only the tab-complete code.

----
Just adds separate UI scale sliders for chat / player list.

I kept `UISize` in there too and gave it some funny logic, so that it acts as a "parent" to the other two.

I.e. if you set `UISizeChat = 3` and `UISizePlayerList = 1`, but then you toggle `UISize` back to 2, the other two flip back to 2 too. It seemed like a neat idea at the time.

`UISizeChat` and `UISizePlayerList` will default to 0, an "illegal" value, and since players currently don't have those in their settings files, it'll end up with those values and detect them, and will set both to the existing `UISize` value.