### PR TITLE
Avoid NREs when the player list handles a packet before the client is ready

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -129,6 +129,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         public void Cleanup() {
+            if (IsGrabbed && Player?.StateMachine.State == Player.StFrozen)
+                Player.StateMachine.State = Player.StNormal;
+
             Player = null;
             PlayerBody = null;
             Session = null;
@@ -138,9 +141,6 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             foreach (Ghost ghost in Ghosts.Values)
                 ghost?.RemoveSelf();
             Ghosts.Clear();
-
-            if (IsGrabbed && Player.StateMachine.State == Player.StFrozen)
-                Player.StateMachine.State = Player.StNormal;
 
             if (PlayerNameTag != null)
                 PlayerNameTag.Name = "";

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -116,7 +116,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         public void RebuildList() {
-            if (MDraw.DefaultFont == null || Client == null || Channels == null)
+            if (MDraw.DefaultFont == null || Client?.PlayerInfo == null || Channels == null)
                 return;
 
             DataPlayerInfo[] all = Client.Data.GetRefs<DataPlayerInfo>();
@@ -474,6 +474,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public void Handle(CelesteNetConnection con, DataPlayerState state) {
             RunOnMainThread(() => {
+                if (MDraw.DefaultFont == null || Client?.PlayerInfo == null || Channels == null)
+                    return;
+
                 // Don't rebuild the entire list
                 // Try to find the player's blob
                 BlobPlayer playerBlob = (BlobPlayer) List?.FirstOrDefault(b => b is BlobPlayer pb && pb.Player == state.Player);
@@ -492,6 +495,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         public void Handle(CelesteNetConnection con, DataConnectionInfo info) {
             RunOnMainThread(() => {
                 if (!ShowPing)
+                    return;
+
+                if (MDraw.DefaultFont == null || Client?.PlayerInfo == null || Channels == null)
                     return;
 
                 // Don't rebuild the entire list


### PR DESCRIPTION
I was debugging something else which involved me rapidly toggling the connection on/off and I kept ending up with this:
```
Ver 1.4.0.0-fna [Everest: 0-dev]
10/17/2022 02:59:04
System.NullReferenceException: Object reference not set to an instance of an object.
   at Celeste.Mod.CelesteNet.Client.Components.CelesteNetPlayerListComponent.<>c__DisplayClass53_0.<Handle>b__2(Channel c) in C:\Program Files (x86)\Steam\steamapps\common\Celeste\Mods\CelesteNet_dev\CelesteNet.Client\Components\CelesteNetPlayerListComponent.cs:line 509
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at Celeste.Mod.CelesteNet.Client.Components.CelesteNetPlayerListComponent.<>c__DisplayClass53_0.<Handle>b__0() in C:\Program Files (x86)\Steam\steamapps\common\Celeste\Mods\CelesteNet_dev\CelesteNet.Client\Components\CelesteNetPlayerListComponent.cs:line 509
   at Celeste.Mod.CelesteNet.Client.CelesteNetClientContext.Update(GameTime gameTime) in C:\Program Files (x86)\Steam\steamapps\common\Celeste\Mods\CelesteNet_dev\CelesteNet.Client\CelesteNetClientContext.cs:line 122
   at Microsoft.Xna.Framework.Game.Update(GameTime gameTime)
   at DMD<Monocle.Engine::Update>(Engine this, GameTime gameTime)
   at Trampoline<Monocle.Engine::Update>?16241458(Engine , GameTime )
   at Celeste.Mod.Procedurline.GlobalManager.EngineUpdateHook(orig_Update orig, Engine engine, GameTime time)
   at Hook<Monocle.Engine::Update>?44034226(Engine , GameTime )
   at Trampoline<Monocle.Engine::Update>?40500813(Engine , GameTime )
   at ExtendedVariants.Variants.NoFreezeFrames.onEngineUpdate(orig_Update orig, Engine self, GameTime gameTime)
   at Hook<Monocle.Engine::Update>?64322318(Engine , GameTime )
   at Trampoline<Monocle.Engine::Update>?14388569(Engine , GameTime )
   at Celeste.Mod.SpeedrunTool.Other.BetterMapEditor.EngineOnUpdate(orig_Update orig, Engine self, GameTime gameTime) in SpeedrunTool/Source/Other/BetterMapEditor.cs:line 250
   at Hook<Monocle.Engine::Update>?16850453(Engine , GameTime )
   at Trampoline<Monocle.Engine::Update>?43489764(Engine , GameTime )
   at Celeste.Mod.SpeedrunTool.Other.RespawnRestartSpeed.RespawnSpeed(orig_Update orig, Engine self, GameTime time) in SpeedrunTool/Source/Other/RespawnRestartSpeed.cs:line 35
   at Hook<Monocle.Engine::Update>?19432409(Engine , GameTime )
   at Celeste.Celeste.Update(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at Microsoft.Xna.Framework.Game.RunLoop()
   at Microsoft.Xna.Framework.Game.Run()
   at Monocle.Engine.RunWithLogging() in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Patches\Monocle\Engine.cs:line 32
```

The relevant bit of code is:
https://github.com/0x0ade/CelesteNet/blob/5ece1516e1f3856f2d5c5904a87f4a2673f358f7/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs#L502-L503

And if I read it correctly, the Exception is thrown inside the predicate of the FirstOrDerfault, so probably by `Client` or `Client.PlayerInfo` being null, right?
I added some checks to the handlers to avoid this stuff. It's a check I took from RebuildList, where I augmented it to not only check `Client` for being null but also `Client.PlayerInfo`.

Per my testing, this eliminates the crash log above.