### PR TITLE
Only ever call Emoji.Fill in the main thread...

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
@@ -46,15 +46,19 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 Type = typeof(Texture2D);
                 Format = "png";
                 PathVirtual = $"emoji/{ID}";
-                Emoji.Register(ID, GFX.Misc["whiteCube"]);
-                Emoji.Fill(CelesteNetClientFont.Font);
+                MainThreadHelper.Do(() => {
+                    Emoji.Register(ID, GFX.Misc["whiteCube"]);
+                    Emoji.Fill(CelesteNetClientFont.Font);
+                });
             }
 
             public void Dispose() {
                 Buffer.Dispose();
                 if (!Pending) {
-                    Emoji.Register(ID, GFX.Misc["whiteCube"]);
-                    Emoji.Fill(CelesteNetClientFont.Font);
+                    MainThreadHelper.Do(() => {
+                        Emoji.Register(ID, GFX.Misc["whiteCube"]);
+                        Emoji.Fill(CelesteNetClientFont.Font);
+                    });
                 }
             }
 

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -247,8 +247,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             if (ghost == null && !IsGhostOutside(Session, level, graphics.Player, out _))
                 ghost = CreateGhost(level, graphics.Player, graphics);
 
-            if (ghost != null)
-                ghost.UpdateGraphics(graphics);
+            if (ghost != null) {
+                ghost.RunOnUpdate(ghost => {
+                    ghost.UpdateGraphics(graphics);
+                });
+            }
         }
 
         public void Handle(CelesteNetConnection con, DataPlayerFrame frame) {


### PR DESCRIPTION
…and same for recurring Ghost.UpdateGraphics.

This is an attempt to fix/prevent this from happening:
```js
Ver 1.4.0.0-fna [Everest: 0-dev]
10/12/2022 23:10:02
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at Celeste.Mod.Emoji.Fill(PixelFont font) in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Mod\Everest\Emoji.cs:line 138
   at Celeste.Mod.CelesteNet.Client.Components.CelesteNetEmojiComponent.<>c__DisplayClass5_1.<Handle>b__0()
   at Celeste.Mod.MainThreadHelper.Update(GameTime gameTime) in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Mod\Helpers\MainThreadHelper.cs:line 132
   at Microsoft.Xna.Framework.Game.Update(GameTime gameTime)
   at Monocle.Engine.Update(GameTime gameTime)
   at Celeste.Celeste.Update(GameTime gameTime)
   at Microsoft.Xna.Framework.Game.Tick()
   at Microsoft.Xna.Framework.Game.RunLoop()
   at Microsoft.Xna.Framework.Game.Run()
   at Monocle.Engine.RunWithLogging() in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Patches\Monocle\Engine.cs:line 32
```

I have a PR with Everest at https://github.com/EverestAPI/Everest/pull/535 but I don't really have any _good_ solution there. This here on the other hand seems to prevent the crash from happening too, as triggerered by CelesteNetEmojiComponent at least.

My method of testing was to have one client with the player list open, and another toggling connect/disconnect (keeps sending new avatar emojis), probably up to a hundred times until eventually there was a good chance of catching this Exception. With the fix applied, I tried for longer without any crash. That's the best evidence I got, that this does in fact prevent the crash.

The other thing in this PR is putting the `ghost.UpdateGraphics(graphics);` inside of a `ghost.RunOnUpdate(ghost => { });` within `Handle(CelesteNetConnection con, DataPlayerGraphics graphics)` just in the feeble hope, that this prevents the highly elusive "ArgumentOutOfRangeException" in PlayerHair.Render from happening.
```js
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
   at System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)
   at DMD<Celeste.PlayerHair::Render>(PlayerHair this)
   at Trampoline<Celeste.PlayerHair::Render>?52550688(PlayerHair )
   at Celeste.Mod.Hyperline.Hyperline.RenderHair(orig_Render orig, PlayerHair self) in F:\Documents\Itch.io-Games\Celeste-Modding\Mods\Hyperline\Hyperline.cs:line 219
   at Hook<Celeste.PlayerHair::Render>?13059294(PlayerHair )
   at Monocle.ComponentList.Render()
   at Monocle.Entity.Render()
   at Monocle.EntityList.RenderExcept(Int32 excludeTags)
   at Celeste.GameplayRenderer.Render(Scene scene) in /home/vsts/work/1/s/Celeste.Mod.mm/Patches/GameplayRenderer.cs:line 11
[...]
```