### PR TITLE
Limit Ghost scale values to 50% - 150%

### DIFF
--- a/CelesteNet.Client/Entities/Ghost.cs
+++ b/CelesteNet.Client/Entities/Ghost.cs
@@ -334,7 +334,11 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
             } else {
                 scale.X = Calc.Clamp(scale.X, -0.5f, -1.5f);
             }
-            scale.Y = Calc.Clamp(scale.Y, 0.5f, 1.5f);
+            if (scale.Y > 0.0f) {
+                scale.Y = Calc.Clamp(scale.Y, 0.5f, 1.5f);
+            } else {
+                scale.Y = Calc.Clamp(scale.Y, -0.5f, -1.5f);
+            }
             Sprite.Scale = scale;
             Sprite.Scale.X *= (float) facing;
             Sprite.Color = color * Alpha;

--- a/CelesteNet.Client/Entities/Ghost.cs
+++ b/CelesteNet.Client/Entities/Ghost.cs
@@ -329,6 +329,12 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         public void UpdateGeneric(Vector2 pos, Vector2 scale, Color color, Facings facing, Vector2 speed) {
             if (Holdable.Holder == null)
                 Position = pos;
+            if (scale.X > 0.0f) {
+                scale.X = Calc.Clamp(scale.X, 0.5f, 1.5f);
+            } else {
+                scale.X = Calc.Clamp(scale.X, -0.5f, -1.5f);
+            }
+            scale.Y = Calc.Clamp(scale.Y, 0.5f, 1.5f);
             Sprite.Scale = scale;
             Sprite.Scale.X *= (float) facing;
             Sprite.Color = color * Alpha;


### PR DESCRIPTION
EmoteMod currently allows setting scale up to 8.0x and this can be pretty annoying/distracting if others do it.

Debug console commands for EmoteMod are `e xy lock` + `e xy 8` as an example:
![image](https://user-images.githubusercontent.com/1682215/198150997-1bc5ae4b-0ab7-4b0d-acb5-ddbd52db7b61.png)

Same Madeline on another client
![image](https://user-images.githubusercontent.com/1682215/198151119-4d9c92b1-1415-4c6f-94f3-b52704daf338.png)

Could also possibly make this a toggleable setting or adjustable limits but idk if that's worth the trouble.