### PR TITLE
Refactor into ResetState, RemoveAllGhosts, use RemoveGhost without logic changes

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -10,7 +10,6 @@ using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
-using Steamworks;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/CelesteNet.Client/Entities/GhostNameTag.cs
+++ b/CelesteNet.Client/Entities/GhostNameTag.cs
@@ -45,7 +45,7 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
 
             float scale = level.GetScreenScale();
 
-            Vector2 pos = Tracking?.Position ?? Position;
+            Vector2 pos = Tracking?.BottomCenter ?? Position;
             pos.Y -= 16f;
 
             pos = level.WorldToScreen(pos);


### PR DESCRIPTION
I tried to do some of the things #29 does without changing any of the logic of it for now. 

Reasoning about #29 might become easier when rebased onto/rewritten on top of this... I dunno.

I know with this Glyph is still as broken as ever and with #29 it seemed a lot better. :widegladeline:

I added the logger warning just in case the change in `void Handle(CelesteNetConnection con, DataPlayerState state)` would somehow turn out not to be equivalent to before, but that'd be really weird.