### PR TITLE
Allow case-insensitive name match before trying StartsWith name matching in chat module.

### DIFF
--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -92,6 +92,9 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
                 index + 1 < raw.Length &&
                 (index = raw.IndexOf(' ', index + 1)) >= 0
             ) {
+                if (index + 1 < raw.Length && raw[index + 1] == ' ')
+                    continue;
+
                 int next = index + 1 < raw.Length ? raw.IndexOf(' ', index + 1) : -2;
                 if (next < 0)
                     next = raw.Length;

--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -151,7 +151,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
 
                 using (Env.Chat.Server.ConLock.R())
                     return
-                        Env.Chat.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName == String) ??
+                        Env.Chat.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.Equals(String, StringComparison.InvariantCultureIgnoreCase) ?? false) ??
                         Env.Chat.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(String, StringComparison.InvariantCultureIgnoreCase) ?? false);
             }
         }


### PR DESCRIPTION
Saw someone trying to TP to someone whose name was the starting letters of another name, e.g. `/tp re` with players `Re` and `Red` online.
Since the casing was different, it didn't hit the `==` path and instead picked the "wrong" match with the `StartsWith`. Hopefully with this at least exact case-insensitive matches will work out. Any "choice" logic beyond is probably gonna be solved once we have tab-completion 😉 

I've given this the most basic of local testing, it's basically just gotten a little more similar to the line below it anyways.

__Edit:__
I've thrown in another bug fix, where previously things went like this:
1. Someone sends `/w   Red hi` with two or more consecutive spaces after the command
2. https://github.com/0x0ade/CelesteNet/blob/f2a093f60e8883996356c9e58c9aadc4c9c8c9fa/CelesteNet.Server.ChatModule/ChatCommands.cs#L91-L106
Before I added in lines 95+96 here, this would start the loop with `index` at the first space, and at line 98 setting effectively `next = index + 1` via `IndexOf`.
Then `int argLength = 0` and `new ChatCMDArg(env).Parse(...)` will just make an arg of type String as a zero-length `Substring`.

4. `ChatCMDWhisper.Run(...)`:
https://github.com/0x0ade/CelesteNet/blob/f2a093f60e8883996356c9e58c9aadc4c9c8c9fa/CelesteNet.Server.ChatModule/CMDs/ChatCMDWhisper.cs#L49
Whisper just goes _"What's the first argument -- in this case `""` -- interpreted as a Player session?"_

7. https://github.com/0x0ade/CelesteNet/blob/f2a093f60e8883996356c9e58c9aadc4c9c8c9fa/CelesteNet.Server.ChatModule/ChatCommands.cs#L157-L158
"Randomly" grab the first player whose name is or starts with `""` and send them the whisper.
🥴 

Solution with minimal changes: Hit a `continue;` when next character at start of loop is also a `' '`.

I've tested locally, sending all sorts of commands with weird spacings and nothing broke, and the bug was gone, seems straight-forward enough as a fix.