### PR TITLE
Only shut down Receive on UDPSocket when UDPReceiver worker cancelled

### DIFF
--- a/CelesteNet.Server/ConPlus/UDPReceiverRole.cs
+++ b/CelesteNet.Server/ConPlus/UDPReceiverRole.cs
@@ -21,7 +21,7 @@ namespace Celeste.Mod.CelesteNet.Server {
                 int dgSize;
 
                 EnterActiveZone();
-                token.Register(() => socket.Close());
+                token.Register(() => socket.ShutdownSafe(SocketShutdown.Receive));
                 while (!token.IsCancellationRequested) {
                     EndPoint dgramSender = socket.LocalEndPoint!;
                     ExitActiveZone();
@@ -33,6 +33,8 @@ namespace Celeste.Mod.CelesteNet.Server {
                             return;
                         throw;
                     }
+                    if (dgSize == 0)
+                        break;
                     EnterActiveZone();
                     ConPlusTCPUDPConnection? con;
 


### PR DESCRIPTION
...because socket might be shared with Sender role.

I was finally investing some time to debug why we're still getting "UDP deaths" every now and then, and Popax spotted this and suggested the fix when we chatted about it.

When the initial role workers get created on startup, the UDPReceiver thread will be using the UDP socket of the Sender role, and everything would be fine up until the moment server load increased enough for it to assign another UDPReceive worker, and then for it to assign the _initial_ UDPReceiver to an Idle role, closing the entire UDP socket in the process. 

![image](https://user-images.githubusercontent.com/1682215/201574924-e3622e55-4a4a-41d0-8376-d4cb67625ef2.png)

![image](https://user-images.githubusercontent.com/1682215/201574957-74144e65-7639-4d67-96c6-debe72bef8fc.png)
