### PR TITLE
Hide targeted messages from public chatlog Endpoint

### DIFF
--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -422,7 +422,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             lock (buffer) {
                 for (int i = Math.Max(-buffer.Moved, -count); i < 0; i++) {
                     DataChat? msg = buffer[i];
-                    if (msg != null && (msg.Target == null || auth))
+                    if (msg != null && ((msg.Targets?.Length ?? 0) == 0 || auth))
                         log.Add(detailed ? msg.ToDetailedFrontendChat() : msg.ToFrontendChat());
                 }
             }


### PR DESCRIPTION
Prevent targeted messages (in channels) from showing up in public chatlog Endpoint.

This fix has already been applied server-side by jade a while ago (around 2022-09-05), it just isn't here in the repo yet. 👍 

(The issue here is that the `Target` property of DataChat is only non-null when `Targets.Count == 1`, for other targeted messages it's still also null, it's a bit of an odd property tbh.)