### PR TITLE
Prevent the Quick Restart menu from reacting to player input after exiting chat

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -284,6 +284,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 Input.ESC.ConsumePress();
                 Input.Pause.ConsumeBuffer();
                 Input.Pause.ConsumePress();
+                Input.QuickRestart.ConsumeBuffer();
+                Input.QuickRestart.ConsumePress();
                 _ConsumeInput--;
             }
 


### PR DESCRIPTION
*(redone #58 but with a new branch this time - oops)*

Self-explanatory.

Although `Input.Pause`, `Input.ESC` and `Input.MenuConfirm` have been accounted for...

https://github.com/0x0ade/CelesteNet/blob/f299779e70499c90c5ccf24ffd9232d1533bbc67/CelesteNet.Client/Components/CelesteNetChatComponent.cs#L279-L288

the `Input.QuickRestart` menu has been left out and still notices the press upon exiting chat.