### PR TITLE
Remove 0xa0 and 0xad from font validation list

### DIFF
--- a/CelesteNet.Shared/CelesteNetUtils.EnglishFontChars.cs
+++ b/CelesteNet.Shared/CelesteNetUtils.EnglishFontChars.cs
@@ -18,6 +18,13 @@ namespace Celeste.Mod.CelesteNet {
 
         // Yes, this is better than trying to find the original font file and parsing it.
 
+        /* 2022-12-18 - RedFlames
+         * I went over the "stranger" looking ones here (i.e. I skipped the
+         * big chunk in the middle that "look like letters" and all that...)
+         * and commented out some like 0xAD (soft-hyphen) that don't render
+         * properly.
+         */
+
         public static readonly char[] EnglishFontChars = new int[] {
             0x0020, //  
             0x0021, // !
@@ -114,7 +121,7 @@ namespace Celeste.Mod.CelesteNet {
             0x007C, // |
             0x007D, // }
             0x007E, // ~
-            0x00A0, //  
+          //0x00A0, //   - see comment at top
             0x00A1, // ¡
             0x00A2, // ¢
             0x00A3, // £
@@ -126,7 +133,7 @@ namespace Celeste.Mod.CelesteNet {
             0x00AA, // ª
             0x00AB, // «
             0x00AC, // ¬
-            0x00AD, // ­
+          //0x00AD, // ­  - see comment at top
             0x00AE, // ®
             0x00AF, // ¯
             0x00B0, // °


### PR DESCRIPTION
Mostly because at one point a guest made their name entirely 0xAD (soft-hyphen) characters and it made it hard to read chat/moderation logs.
The 0xA0 which I think is `&nbsp;` basically just doesn't render?

Soft-hyphen does render as a whitespace. Which made me wonder, why _are_ we stripping all spaces from names and not just trimming the edges after sanitization? Is it because `/tp oh hi marc` would be harder to parse if the user "oh hi marc" had spaces in their name? 🤔 
Or are there more reasons I'm not thinking of. I guess spaces in names & channel names might allow some shenanigans to be caused, not sure.

Soft-hyphen also suffers from the same issue that _a lot_ of the more special:tm: characters suffer from, which is that they render as Â or â or something similar when put at the start of a name or message... I don't _think_ it's the text rendering's fault, is it somewhere in the network protocol or in the user store module? I suppose it's a bug worth investigating...
At least this bug just about guarantees that noone could make their name entirely blank :P 

PS: Meant to write it in the comment in the code but I tested by running the hex values through a hex-to-ascii/unicode site, sprinkling in valid chars in between to make sure I catch everything right, and CTRL-V'd them into Everest's text input of the Name/Key mod setting. I wasn't terribly rigorous though. 
I did notice that if you have a `'` or `"` in it, in `modsettings-CelesteNet.Client.celeste` it saves as `Name: "a\"b'c"` throwing in quotes and escaping the quote inside, so the config files generally don't care at least!