### PR TITLE
Fix mangled first char if its codepoint is > 0x7F

### DIFF
--- a/CelesteNet.Shared/CelesteNetBinaryReader.cs
+++ b/CelesteNet.Shared/CelesteNetBinaryReader.cs
@@ -83,7 +83,7 @@ namespace Celeste.Mod.CelesteNet {
         }
 
         public virtual string ReadNetString() {
-            char c = (char) ReadByte();
+            char c = ReadChar();
             if (c == NetStringCtrl.Mapped)
                 throw new Exception("Trying to read a mapped string as a non-mapped string!");
 
@@ -103,7 +103,7 @@ namespace Celeste.Mod.CelesteNet {
         public virtual string ReadNetMappedString() {
             string value;
 
-            char c = (char) ReadByte();
+            char c = ReadChar();
             if (c == NetStringCtrl.Mapped) {
                 if (Strings == null)
                     throw new Exception("Trying to read a mapped string without a string map!");

--- a/CelesteNet.Shared/CelesteNetBinaryWriter.cs
+++ b/CelesteNet.Shared/CelesteNetBinaryWriter.cs
@@ -108,7 +108,7 @@ namespace Celeste.Mod.CelesteNet {
                         throw new ArgumentException("Cannot use reserved control strings.");
                     if (text.Length > 1)
                         throw new ArgumentException("Control strings cannot be used to start a string.");
-                    Write((byte) text[0]);
+                    Write(text[0]);
                     return;
                 }
 
@@ -132,7 +132,7 @@ namespace Celeste.Mod.CelesteNet {
                 return;
             }
 
-            Write((byte) NetStringCtrl.Mapped);
+            Write(NetStringCtrl.Mapped);
             Write7BitEncodedInt(id);
         }
 


### PR DESCRIPTION
###### *About time this one got fixed!*

### TL;DR
The server and the client read what the other party sent wrong. That's it.

## What?

Sending a message which starts with an accented character *(like `ó`, `ł`, `ß`, etc..)* mangles the start of the message:
![Mangled first character](https://user-images.githubusercontent.com/49392266/208489494-17e10be8-e87d-4dca-8309-8a560aff1b4c.png)

## Why?
There's a bug in `CelesteNetBinaryReader`: `ReadNetString()` and `ReadNetMappedString()` read the first `byte` and cast it to a `char`, without taking UTF-8 sequences longer than 1 byte into consideration *(which applies to all codepoints beyond `0x7F`)*:
https://github.com/0x0ade/CelesteNet/blob/f0ab172b079e35f258170e15a518ace1d1feda1d/CelesteNet.Shared/CelesteNetBinaryReader.cs#L85-L101
https://github.com/0x0ade/CelesteNet/blob/f0ab172b079e35f258170e15a518ace1d1feda1d/CelesteNet.Shared/CelesteNetBinaryReader.cs#L103-L125

Let's make an example with the string **"ówó"** *(`F3 77 F3`)*.
1. The message is UTF-8 encoded into the following bytes and then sent to the server: `C3 B3 77 C3 B3`
No problems there. Even the client sees the message correctly before it reaches the server:
![Before the message reaches the server](https://user-images.githubusercontent.com/49392266/208493793-a306df30-4c7f-446b-8d0a-ce694dae0680.png)
1. The server receives the packet and proceeds to read the chat message:
https://github.com/0x0ade/CelesteNet/blob/f0ab172b079e35f258170e15a518ace1d1feda1d/CelesteNet.Shared/CelesteNetBinaryReader.cs#L85-L101
    - We do a `ReadByte()` *(`0xC3`)*, cast it into a `char` and store it in `c`.
    - We then enter `ReadNetStringCore()`:
    https://github.com/0x0ade/CelesteNet/blob/f0ab172b079e35f258170e15a518ace1d1feda1d/CelesteNet.Shared/CelesteNetBinaryReader.cs#L56-L83
    - Proceeding onwards we hit a `ReadChar()` *(`0xB3`)*, but we are in the middle of a UTF-8 sequence!
    Hitting an unexpected continuation byte causes the `UTF8Decoder` inside the `BinaryReader` to return `0xFFFD`.
    *(yes, C# chars are actually `ushort`s.)*
    - The rest of the characters are read as normal. The read string becomes `Ã�wó` *(`C3 FFFD 77 F3`)*.
1. The message is then processed, UTF-8 encoded again and sent to the client as these bytes: `C3 83 EF BF BD 77 C3 B3`
1. The client receives the message and the same steps in 2. are taken, mangling the string once more, making it `Ã��wó` *(`C3 FFFD FFFD 77 F3`)*.

The `\uFFFD` characters are not rendered and as a result, we get our *beautiful* **"Ãwó"**.

## Caveats

Because `/gc ówó`, `/cc ówó` and `/w <...> ówó` do not begin with a character above 0x7F *(cus they begin with `/`, duh)*, this makes the server read our message fine, but the client mangles them once, which lets us see characters other than `Ã` *(here achieved with `\u0180`, `ƀ`)*:
![Only one mangle](https://user-images.githubusercontent.com/49392266/208504305-757c014c-60f5-49df-8656-373cf7b6ec4c.png)

`/join ówó` is also affected by this, in certain circumstances allowing people to enter unnamed channels. *(pretty secure if ya ask me)*
![Unnamed channel](https://user-images.githubusercontent.com/49392266/208506382-5590db75-2293-47f0-b2b3-34a55c040ba1.png)

## The fix
Just use `ReadChar()` directly. It respects the UTF-8 sequences and besides -- the control characters are only 1 byte long and below `0x7F` anyway.
![Fixed messages](https://user-images.githubusercontent.com/49392266/208513168-bc5d90f0-1097-4413-be98-28a454c9232f.png)
