### PR TITLE
Create CelesteNet.Server.FilterModule

### DIFF
--- a/CelesteNet.Server.FilterModule/CelesteNet.Server.FilterModule.csproj
+++ b/CelesteNet.Server.FilterModule/CelesteNet.Server.FilterModule.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <LangVersion>9</LangVersion> <!-- FIXME: Figure out why dotnet needs this! -->
+    <TargetFrameworks>net452;net6.0</TargetFrameworks>
+    <AssemblyName>CelesteNet.Server.FilterModule</AssemblyName>
+    <RootNamespace>Celeste.Mod.CelesteNet.Server.Filter</RootNamespace>
+  </PropertyGroup>
+
+  <Import Project="..\CelesteNet.props" />
+
+</Project>

--- a/CelesteNet.Server.FilterModule/FilterModule.cs
+++ b/CelesteNet.Server.FilterModule/FilterModule.cs
@@ -46,11 +46,13 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
 
         private void OnConnect(CelesteNetServer server, CelesteNetConnection con) {
             con.OnSendFilter += ConSendFilter;
+            ((ConPlusTCPUDPConnection) con).OnDequeueFilter += ConSendFilter;
             con.OnDisconnect += OnDisconnect;
         }
 
         private void OnDisconnect(CelesteNetConnection con) {
             con.OnSendFilter -= ConSendFilter;
+            ((ConPlusTCPUDPConnection) con).OnDequeueFilter -= ConSendFilter;
             if (Settings.Enabled && Settings.PrintSessionStatsOnEnd) {
                 CelesteNetConnection c;
                 string type;

--- a/CelesteNet.Server.FilterModule/FilterModule.cs
+++ b/CelesteNet.Server.FilterModule/FilterModule.cs
@@ -23,6 +23,9 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
         public override void Init(CelesteNetServerModuleWrapper wrapper) {
             base.Init(wrapper);
 
+            if (!Settings.Enabled)
+                return;
+
             Server.OnConnect += OnConnect;
             using (Server.ConLock.R())
                 foreach (CelesteNetConnection con in Server.Connections)
@@ -31,6 +34,9 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
 
         public override void Dispose() {
             base.Dispose();
+
+            if (!Settings.Enabled)
+                return;
 
             Server.OnConnect -= OnConnect;
             using (Server.ConLock.R())
@@ -45,7 +51,7 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
 
         private void OnDisconnect(CelesteNetConnection con) {
             con.OnSendFilter -= ConSendFilter;
-            if (Settings.PrintSessionStatsOnEnd) {
+            if (Settings.Enabled && Settings.PrintSessionStatsOnEnd) {
                 CelesteNetConnection c;
                 string type;
                 foreach (var kv in Counts) {
@@ -83,6 +89,9 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
         }
 
         public bool Filter(CelesteNetConnection con, DataType data) {
+            if (!Settings.Enabled)
+                return true;
+
             string type = data.GetTypeID(Server.Data);
 
             PacketCounts? counts = null;
@@ -103,7 +112,7 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
             return FilterInner(ref filter, ref key, ref counts);
         }
 
-        public bool FilterInner(ref FilterSettings.FilterDef filter, ref Tuple<CelesteNetConnection, string> key, ref PacketCounts? counts) {
+        private bool FilterInner(ref FilterSettings.FilterDef filter, ref Tuple<CelesteNetConnection, string> key, ref PacketCounts? counts) {
 
             if (counts == null) {
                 counts = Counts.GetOrAdd(key, new PacketCounts());
@@ -125,6 +134,9 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
         }
 
         public bool ConSendFilter(CelesteNetConnection con, DataType data) {
+            if (!Settings.Enabled)
+                return true;
+
             string type = data.GetTypeID(Server.Data);
 
             PacketCounts? counts = null;
@@ -145,7 +157,7 @@ namespace Celeste.Mod.CelesteNet.Server.Filter {
             return ConSendFilterInner(ref filter, ref key, ref counts);
         }
 
-        public bool ConSendFilterInner(ref FilterSettings.FilterDef filter, ref Tuple<CelesteNetConnection, string> key, ref PacketCounts? counts) {
+        private bool ConSendFilterInner(ref FilterSettings.FilterDef filter, ref Tuple<CelesteNetConnection, string> key, ref PacketCounts? counts) {
 
             if (counts == null) {
                 counts = Counts.GetOrAdd(key, new PacketCounts());

--- a/CelesteNet.Server.FilterModule/FilterModule.cs
+++ b/CelesteNet.Server.FilterModule/FilterModule.cs
@@ -1,0 +1,170 @@
+﻿using Celeste.Mod.CelesteNet.DataTypes;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.CelesteNet.Server.Filter {
+    public class FilterModule : CelesteNetServerModule<FilterSettings> {
+
+        public class PacketCounts {
+            public int InCount = 0;
+            public int OutCount = 0;
+            public int InDrop = 0;
+            public int OutDrop = 0;
+        }
+
+        private readonly ConcurrentDictionary<Tuple<CelesteNetConnection, string>, PacketCounts> Counts = new ();
+
+        private Random rng = new ();
+
+        public override void Init(CelesteNetServerModuleWrapper wrapper) {
+            base.Init(wrapper);
+
+            Server.OnConnect += OnConnect;
+            using (Server.ConLock.R())
+                foreach (CelesteNetConnection con in Server.Connections)
+                    OnConnect(Server, con);
+        }
+
+        public override void Dispose() {
+            base.Dispose();
+
+            Server.OnConnect -= OnConnect;
+            using (Server.ConLock.R())
+                foreach (CelesteNetConnection con in Server.Connections)
+                    con.OnDisconnect -= OnDisconnect;
+        }
+
+        private void OnConnect(CelesteNetServer server, CelesteNetConnection con) {
+            con.OnSendFilter += ConSendFilter;
+            con.OnDisconnect += OnDisconnect;
+        }
+
+        private void OnDisconnect(CelesteNetConnection con) {
+            con.OnSendFilter -= ConSendFilter;
+            if (Settings.PrintSessionStatsOnEnd) {
+                CelesteNetConnection c;
+                string type;
+                foreach (var kv in Counts) {
+                    (c, type) = kv.Key;
+                    PacketCounts val = kv.Value;
+
+                    if (c != con)
+                        continue;
+
+                    LogStats($"{con.ID} - packets {type,14}", val, outbound: true);
+                    LogStats($"{con.ID} - packets {type,14}", val, outbound: false);
+                }
+                if (Settings.PrintAllSessionStats) {
+                    foreach (var kv in Counts) {
+                        (c, type) = kv.Key;
+                        PacketCounts val = kv.Value;
+
+                        if (c != con)
+                            continue;
+
+                        if (val.OutCount == 0 && val.OutDrop == 0)
+                            LogStats($"{con.ID} - packets {type,14}", val, outbound: true, forcePrint: true);
+                        if (val.InCount == 0 && val.InDrop == 0)
+                            LogStats($"{con.ID} - packets {type,14}", val, outbound: false, forcePrint: true);
+                    }
+                }
+            }
+        }
+
+        private void LogStats(string info, PacketCounts val, bool outbound, bool forcePrint = false) {
+            int count = outbound ? val.OutCount : val.InCount;
+            int dropped = outbound ? val.OutDrop : val.InDrop;
+            if (forcePrint || count > 0 || dropped > 0)
+                Logger.Log(LogLevel.INF, "filtermod", $"{info} - {(outbound ? "Outbound" : " Inbound")}: {count,3} (dropped {dropped,3})");
+        }
+
+        public bool Filter(CelesteNetConnection con, DataType data) {
+            string type = data.GetTypeID(Server.Data);
+
+            PacketCounts? counts = null;
+            Tuple<CelesteNetConnection, string>? key = null;
+
+            if (Settings.CollectAllSessionStats) {
+                key = Tuple.Create(con, type);
+                counts = Counts.GetOrAdd(key, new PacketCounts());
+                counts.InCount++;
+            }
+
+            // check if type matches inbound filter rule
+            if (type.IsNullOrEmpty() || !Settings.FiltersInbound.TryGetValue(type, out FilterSettings.FilterDef filter))
+                return true;
+
+            // handle the filter in inner method, provide tuple for dictionaries
+            key ??= Tuple.Create(con, type);
+            return FilterInner(ref filter, ref key, ref counts);
+        }
+
+        public bool FilterInner(ref FilterSettings.FilterDef filter, ref Tuple<CelesteNetConnection, string> key, ref PacketCounts? counts) {
+
+            if (counts == null) {
+                counts = Counts.GetOrAdd(key, new PacketCounts());
+                counts.InCount++;
+            }
+
+            bool belowThreshold = counts.InCount <= filter.DropThreshold;
+            bool aboveLimit = filter.DropLimit > 0 && counts.InDrop >= filter.DropLimit;
+
+            if (belowThreshold || aboveLimit)
+                return true;
+
+            if (rng.Next(100) > filter.DropChance)
+                return true;
+
+            Logger.Log(LogLevel.WRN, "filtermod", $"Con #{key.Item1.ID} Filter INBOUND '{key.Item2}' - dropped ({filter.DropThreshold}) < {counts.InCount} / ({filter.DropLimit}) < {counts.InDrop}");
+            counts.InDrop++;
+            return false;
+        }
+
+        public bool ConSendFilter(CelesteNetConnection con, DataType data) {
+            string type = data.GetTypeID(Server.Data);
+
+            PacketCounts? counts = null;
+            Tuple<CelesteNetConnection, string>? key = null;
+
+            if (Settings.CollectAllSessionStats) {
+                key = Tuple.Create(con, type);
+                counts = Counts.GetOrAdd(key, new PacketCounts());
+                counts.OutCount++;
+            }
+
+            // check if type matches outbound filter rule
+            if (type.IsNullOrEmpty() || !Settings.FiltersOutbound.TryGetValue(type, out FilterSettings.FilterDef filter))
+                return true;
+
+            // handle the filter in inner method, provide tuple for dictionaries
+            key ??= Tuple.Create(con, type);
+            return ConSendFilterInner(ref filter, ref key, ref counts);
+        }
+
+        public bool ConSendFilterInner(ref FilterSettings.FilterDef filter, ref Tuple<CelesteNetConnection, string> key, ref PacketCounts? counts) {
+
+            if (counts == null) {
+                counts = Counts.GetOrAdd(key, new PacketCounts());
+                counts.OutCount++;
+            }
+
+            bool belowThreshold = counts.OutCount <= filter.DropThreshold;
+            bool aboveLimit = filter.DropLimit > 0 && counts.OutDrop > filter.DropLimit;
+
+            if (belowThreshold || aboveLimit)
+                return true;
+
+            if (rng.Next(100) > filter.DropChance)
+                return true;
+
+            Logger.Log(LogLevel.WRN, "filtermod", $"Con #{key.Item1.ID} Filter OUTBOUND '{key.Item2}' - dropped ({filter.DropThreshold}) < {counts.OutCount} / ({filter.DropLimit}) <= {counts.OutDrop}");
+            counts.OutDrop++;
+            return false;
+        }
+
+    }
+}

--- a/CelesteNet.Server.FilterModule/FilterSettings.cs
+++ b/CelesteNet.Server.FilterModule/FilterSettings.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 namespace Celeste.Mod.CelesteNet.Server.Filter {
     public class FilterSettings : CelesteNetServerModuleSettings {
 
+        public bool Enabled { get; set; } = false;
         public bool PrintSessionStatsOnEnd { get; set; } = false;
         public bool CollectAllSessionStats { get; set; } = false;
         public bool PrintAllSessionStats { get; set; } = false;

--- a/CelesteNet.Server.FilterModule/FilterSettings.cs
+++ b/CelesteNet.Server.FilterModule/FilterSettings.cs
@@ -1,0 +1,23 @@
+﻿using Celeste.Mod.CelesteNet.DataTypes;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.CelesteNet.Server.Filter {
+    public class FilterSettings : CelesteNetServerModuleSettings {
+
+        public bool PrintSessionStatsOnEnd { get; set; } = false;
+        public bool CollectAllSessionStats { get; set; } = false;
+        public bool PrintAllSessionStats { get; set; } = false;
+
+        /* dict key is DataID of DataType class to filter */
+        public Dictionary<string, FilterDef> FiltersInbound { get; set; } = new ();
+        public Dictionary<string, FilterDef> FiltersOutbound { get; set; } = new ();
+
+        public class FilterDef {
+            public int DropThreshold { get; set; } = -1;
+            public int DropLimit { get; set; } = -1;
+            public int DropChance { get; set; } = 100;
+
+        }
+
+    }
+}

--- a/CelesteNet.sln
+++ b/CelesteNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CelesteNet.Shared", "CelesteNet.Shared\CelesteNet.Shared.csproj", "{DF8E8764-60D1-4EC8-9997-4208551B4EC1}"
 EndProject
@@ -62,6 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "emoji", "emoji", "{273EB989
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CelesteNet.Server.SqliteModule", "CelesteNet.Server.SqliteModule\CelesteNet.Server.SqliteModule.csproj", "{A43B6AC6-3305-4DCC-B8AE-A3FD7ACB3547}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CelesteNet.Server.FilterModule", "CelesteNet.Server.FilterModule\CelesteNet.Server.FilterModule.csproj", "{341F5432-743A-4841-A171-16EFE599ED9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,10 @@ Global
 		{A43B6AC6-3305-4DCC-B8AE-A3FD7ACB3547}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A43B6AC6-3305-4DCC-B8AE-A3FD7ACB3547}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A43B6AC6-3305-4DCC-B8AE-A3FD7ACB3547}.Release|Any CPU.Build.0 = Release|Any CPU
+		{341F5432-743A-4841-A171-16EFE599ED9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{341F5432-743A-4841-A171-16EFE599ED9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{341F5432-743A-4841-A171-16EFE599ED9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{341F5432-743A-4841-A171-16EFE599ED9E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
...for arbitrarily dropping packets on their way in/out of the server for debugging.

Filter rules look like this: (with default values)
```yaml
  keepAlive:
    DropThreshold: -1
    DropLimit: -1
    DropChance: 100
```
 * `DropThreshold`: Allow first `n` packets through
 * `DropLimit`: After dropping `n` packets, start letting them through again
 * `DropChance`: Percentage chance of a packet being dropped

(Actually `DropThreshold` and `DropLimit` are somewhat independent, so `DropThreshold=5, DropLimit=5` would actually make sense, in that it would first let 5 packets through, *then* drop 5, *then* cease filtering.)

![image](https://user-images.githubusercontent.com/1682215/210124163-d730ae19-ecc2-4ef4-a2a8-c3655a946612.png)

Full example config that tries to drop just about everything, and somehow client still stays connected:
```yaml
Enabled: true
PrintSessionStatsOnEnd: true
CollectAllSessionStats: true
PrintAllSessionStats: false
FiltersInbound:
  keepAlive:
    DropThreshold: -1
    DropLimit: -1
    DropChance: 100
  pingReply: {}
  filterList: {}
FiltersOutbound:
  ready: {}
  channelList: {}
  keepAlive: {}
  pingRequest: {}
  playerInfo: {}
  netemoji: {}
  filterList: {}
  playerInfo: {}
  serverStatus: {}
  tickRate: {}
  conInfo: {}
  stringMap: {}
  udpInfo: {}
  channelMove: {}
  channelList: {}
  chat: {}
  slimMap: {}
```
(the empty objects use the default values)
