### PR TITLE
Fix freezes and issues cause by ReadyEvent / CancelationToken

### DIFF
--- a/CelesteNet.Client/CelesteNetClient.cs
+++ b/CelesteNet.Client/CelesteNetClient.cs
@@ -63,7 +63,8 @@ namespace Celeste.Mod.CelesteNet.Client {
                 try {
                     if (!typeof(IConnectionFeature).IsAssignableFrom(type) || type.IsAbstract)
                         continue;
-                } catch {
+                } catch (Exception e) {
+                    Logger.Log(LogLevel.VVV, "main", $"CelesteNetClient - conFeature threw {e.Message}");
                     continue;
                 }
 
@@ -224,9 +225,9 @@ namespace Celeste.Mod.CelesteNet.Client {
                 }
             }
 
-            // Wait until the server sent the ready packet, or run into timeout
-            if (!_ReadyEvent.Wait(5000, token))
-                throw new Exception($"Client startup timed out while waiting for Ready event.");
+            Logger.Log(LogLevel.VVV, "main", $"Client Start: Waiting for Ready");
+            // Wait until the server sent the ready packet
+            _ReadyEvent.Wait(token);
             SendFilterList();
 
             Logger.Log(LogLevel.INF, "main", "Ready");

--- a/CelesteNet.Client/CelesteNetClient.cs
+++ b/CelesteNet.Client/CelesteNetClient.cs
@@ -224,8 +224,9 @@ namespace Celeste.Mod.CelesteNet.Client {
                 }
             }
 
-            // Wait until the server sent the ready packet
-            _ReadyEvent.Wait(token);
+            // Wait until the server sent the ready packet, or run into timeout
+            if (!_ReadyEvent.Wait(5000, token))
+                throw new Exception($"Client startup timed out while waiting for Ready event.");
             SendFilterList();
 
             Logger.Log(LogLevel.INF, "main", "Ready");

--- a/CelesteNet.Client/CelesteNetClientContext.cs
+++ b/CelesteNet.Client/CelesteNetClientContext.cs
@@ -123,7 +123,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                 MainThreadQueue.Clear();
             }
 
-            if (Client?.SafeDisposeTriggered ?? false)
+            if ((Client?.SafeDisposeTriggered ?? false) && (Client?.IsAlive ?? false))
                 Client.Dispose();
         }
 

--- a/CelesteNet.Client/CelesteNetClientContext.cs
+++ b/CelesteNet.Client/CelesteNetClientContext.cs
@@ -133,7 +133,8 @@ namespace Celeste.Mod.CelesteNet.Client {
             // This must happen at the very end, as XNA / FNA won't update their internal lists, causing "dead" components to update.
 
             if (SafeDisposeTriggered) {
-                Dispose();
+                if (!IsDisposed)
+                    Dispose();
                 return;
             }
 

--- a/CelesteNet.Client/CelesteNetClientContext.cs
+++ b/CelesteNet.Client/CelesteNetClientContext.cs
@@ -146,7 +146,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                         // FIXME: Make sure that nothing tries to make use of the dead connection until the restart.
                         if (Status.Spin)
                             Status.Set("Disconnected", 3f, false);
-                        QueuedTaskHelper.Do(new Tuple<object, string>(this, "CelesteNetAutoReconnect"), 1D, () => {
+                        QueuedTaskHelper.Do(new Tuple<object, string>(this, "CelesteNetAutoReconnect"), 2D, () => {
                             if (CelesteNetClientModule.Instance.Context == this)
                                 CelesteNetClientModule.Instance.Start();
                         });


### PR DESCRIPTION
When the client doesn't receive a DataReady after an auto-reconnect ran, it will just complete freeze, "not responding". This change fixes that for me at least. I am unsure if this helps with other "still responsive" game freezes because of auto-reconnect.

Edit:
Changed from the timeout to fixing the Cancelation token life cycle, hopefully.

Besides that, in CelesteNetRenderHelperComponent Initialize and Disconnect make sure to set/unset the render hooks & handle render targets from main thread in a blocking way. Couldn't quite do that in Dispose because of the need to go through Context for the main thread handler function...

Oh, and I increased the Auto-reconnect delay from one to two seconds, because eventually I still want to make that an exponential back-off for when connections fail _a lot_... :'D

(Other change: Let's not call Client.Dispose more than once from context Update(), just in case...)