### PR TITLE
Add Send/Run buttons to Chat/Cmd panels

### DIFF
--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
@@ -300,6 +300,12 @@ main {
 .panel-chat > .panel-input > .mdc-text-field {
     width: 100%;
 }
+
+.panel-cmd > .panel-input,
+.panel-chat > .panel-input {
+    display: flex;
+}
+
 .panel-notes > .panel-text > .mdc-text-field,
 .panel-notes > .panel-text > .mdc-text-field > .mdc-text-field__resizer,
 .panel-notes > .panel-text > .mdc-text-field > .mdc-text-field__resizer > textarea {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
@@ -304,6 +304,7 @@ main {
 .panel-cmd > .panel-input,
 .panel-chat > .panel-input {
     display: flex;
+    align-items: center;
 }
 
 .panel-notes > .panel-text > .mdc-text-field,

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -158,7 +158,8 @@ export class FrontendChatPanel extends FrontendBasicPanel {
           this.send();
         }
       })}
-    </div>`
+      ${mdcrd.iconButton("Send", "send", () => { this.send(); })}
+    </div>`;
   }
 
   send(text) {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/cmd.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/cmd.js
@@ -59,6 +59,7 @@ export class FrontendCMDPanel extends FrontendBasicPanel {
           this.run();
         }
       })}
+      ${mdcrd.iconButton("Run", "send", () => { this.run(); })}
     </div>`
   }
 


### PR DESCRIPTION
What it says right there. Apparently on some mobile browsers hitting send/Enter in the inputs doesn't trigger an `e.keyCode == 13` input, so I'm adding an icon button to send.

![image](https://user-images.githubusercontent.com/1682215/211635462-bc5800fc-e647-453e-aa38-866be94f3fe7.png)
