### PR TITLE
Make DataNetFilterList not a BoundRef / do 'last channel' move in ses.Start instead of delegate

### DIFF
--- a/CelesteNet.Server/Channels.cs
+++ b/CelesteNet.Server/Channels.cs
@@ -31,8 +31,6 @@ namespace Celeste.Mod.CelesteNet.Server {
             Server.Data.RegisterHandlersIn(this);
 
             Default = new(this, NameDefault, 0);
-
-            Server.OnSessionStart += OnSessionStart;
         }
 
         public void Start() {
@@ -43,14 +41,16 @@ namespace Celeste.Mod.CelesteNet.Server {
             Logger.Log(LogLevel.INF, "channels", "Shutdown");
         }
 
-        private void OnSessionStart(CelesteNetPlayerSession session) {
+        public bool SessionStartupMove(CelesteNetPlayerSession session) {
             if (Server.UserData.TryLoad(session.UID, out LastChannelUserInfo last) &&
                 last.Name != NameDefault) {
-                Move(session, last.Name);
+                (Channel curr, Channel prev) = Move(session, last.Name);
+                return curr != prev;
             } else {
                 Default.Add(session);
                 BroadcastList();
             }
+            return false;
         }
 
         public void SendListTo(CelesteNetPlayerSession session) {

--- a/CelesteNet.Shared/DataTypes/DataNetFilterList.cs
+++ b/CelesteNet.Shared/DataTypes/DataNetFilterList.cs
@@ -18,19 +18,8 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
 
         public override DataFlags DataFlags => DataFlags.Taskable;
 
-        public DataPlayerInfo? Player;
-
         public string[] List = Dummy<string>.EmptyArray;
         private HashSet<string>? Set;
-
-        public override MetaType[] GenerateMeta(DataContext ctx)
-            => new MetaType[] {
-                new MetaBoundRef(DataPlayerInfo.DataID, Player?.ID ?? uint.MaxValue, true)
-            };
-
-        public override void FixupMeta(DataContext ctx) {
-            Player = ctx.GetRef<DataPlayerInfo>(Get<MetaBoundRef>(ctx).ID);
-        }
 
         protected override void Read(CelesteNetBinaryReader reader) {
             List = new string[reader.ReadUInt16()];


### PR DESCRIPTION
Change DataNetFilterList to not be a BoundRef and instead use a Handler in CelesteNetPlayerSession to get it

Also, actively do the 'last channel' move in session.Start() instead of via delegate invoke 

![image](https://user-images.githubusercontent.com/1682215/212501954-428ef710-26f0-4a2f-8263-1acd4aa63616.png)

The invoke happens _right_ after Start anyway so hopefully this is practically the same thing.

### Some context for these changes:
The persistent disconnect issue as far as we're currently aware is caused by overrunning the TCP send queue during connection, with two bad contributing factors:
 - ResendPlayerStates got called in session Start _and_ in Channels.Move which was called by the session start delegate, if the player had a stored "last channel"
 - there's some data classes where it's highly questionable if they should be sent to all other clients, one clear example is DataNetFilterList of all sessions being sent simply because it has a bound ref

For example, I looked at one failed connection, the queue was filled like this
\+ 78 PlayerInfos 
\+ 391 AvatarFragments 
\+ 199 bound refs (session Start) 
\+ 199 bound refs (session Start ResendPlayerStates) 
\+ 199 bound refs (Channels Move ResendPlayerStates) 
= 1000+ queued packets and there's also DataReady and TickRate and such in there