### PR TITLE
Make Shutdown work correctly

### DIFF
--- a/CelesteNet.Server/ConPlus/TCPEPollPoller.cs
+++ b/CelesteNet.Server/ConPlus/TCPEPollPoller.cs
@@ -91,8 +91,8 @@ namespace Celeste.Mod.CelesteNet.Server {
 
                 Connections.Clear();
                 ConIds.Clear();
-                PollerLock.Dispose();
             }
+            PollerLock.Dispose();
         }
 
         public void AddConnection(ConPlusTCPUDPConnection con) {

--- a/CelesteNet.Server/ConPlus/TCPFallbackPoller.cs
+++ b/CelesteNet.Server/ConPlus/TCPFallbackPoller.cs
@@ -22,8 +22,8 @@ namespace Celeste.Mod.CelesteNet.Server {
             using (PollerLock.W()) {
                 Cons.Clear();
                 ConQueue.Dispose();
-                PollerLock.Dispose();
             }
+            PollerLock.Dispose();
         }
 
         public void AddConnection(ConPlusTCPUDPConnection con) {

--- a/CelesteNet.Server/NetPlus/ThreadPool.cs
+++ b/CelesteNet.Server/NetPlus/ThreadPool.cs
@@ -63,14 +63,14 @@ namespace Celeste.Mod.CelesteNet.Server {
             using (_PoolLock.W())
             using (_RoleLock.W()) {
                 // Stop threads
-                TokenSrc.Dispose();
+                TokenSrc.Cancel();
                 foreach (NetPlusThread thread in Threads)
                     thread.Thread.Join();
-
+                TokenSrc.Dispose();
                 RuntimeWatch.Stop();
-                _RoleLock.Dispose();
-                _PoolLock.Dispose();
             }
+            _RoleLock.Dispose();
+            _PoolLock.Dispose();
         }
 
         public float IterateSteadyHeuristic(ref float lastVal, ref long lastUpdate, float curVal, bool update = false) {

--- a/CelesteNet.Server/NetPlus/ThreadRole.cs
+++ b/CelesteNet.Server/NetPlus/ThreadRole.cs
@@ -32,8 +32,9 @@ namespace Celeste.Mod.CelesteNet.Server {
             }
 
             public virtual void Dispose() {
-                using (Role.WorkerLock.W())
-                    Role.Workers.Remove(this);
+                if (Role.Workers.Contains(this))
+                    using (Role.WorkerLock.W())
+                        Role.Workers.Remove(this);
                 ActivityLock.Dispose();
             }
 
@@ -84,8 +85,8 @@ namespace Celeste.Mod.CelesteNet.Server {
 
             using (WorkerLock.W()) {
                 Workers.Clear();
-                WorkerLock.Dispose();
             }
+            WorkerLock.Dispose();
         }
 
         public virtual void InvokeSchedular() {}

--- a/CelesteNet.Server/Program.cs
+++ b/CelesteNet.Server/Program.cs
@@ -138,6 +138,7 @@ namespace Celeste.Mod.CelesteNet.Server {
             using CelesteNetServer server = Server = new(settings);
             server.Start();
             server.Wait();
+            server.Dispose();
             Server = null;
         }
 

--- a/CelesteNet.Shared/RWLock.cs
+++ b/CelesteNet.Shared/RWLock.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 namespace Celeste.Mod.CelesteNet {
     public class RWLock : IDisposable {
 
-        public readonly ReaderWriterLockSlim Inner = new(LockRecursionPolicy.SupportsRecursion);
+        private readonly ReaderWriterLockSlim Inner = new(LockRecursionPolicy.SupportsRecursion);
         private readonly RLock _R;
         private readonly RULock _RU;
         private readonly WLock _W;
@@ -36,7 +36,7 @@ namespace Celeste.Mod.CelesteNet {
         }
 
         public class RLock : IDisposable {
-            public readonly ReaderWriterLockSlim Inner;
+            private readonly ReaderWriterLockSlim Inner;
 
             public RLock(ReaderWriterLockSlim inner) {
                 Inner = inner;
@@ -53,7 +53,7 @@ namespace Celeste.Mod.CelesteNet {
         }
 
         public class RULock : IDisposable {
-            public readonly ReaderWriterLockSlim Inner;
+            private readonly ReaderWriterLockSlim Inner;
 
             public RULock(ReaderWriterLockSlim inner) {
                 Inner = inner;
@@ -70,7 +70,7 @@ namespace Celeste.Mod.CelesteNet {
         }
 
         public class WLock : IDisposable {
-            public readonly ReaderWriterLockSlim Inner;
+            private readonly ReaderWriterLockSlim Inner;
 
             public WLock(ReaderWriterLockSlim inner) {
                 Inner = inner;


### PR DESCRIPTION
I wrote this based off the exceptions that happen when you call /api/shutdown

![image](https://user-images.githubusercontent.com/1682215/212729183-3dc316fd-ff9c-45f0-abc8-31cc91f96508.png)

![image](https://user-images.githubusercontent.com/1682215/212729228-38cbeaa7-a278-4c7a-9578-f2a575956aee.png)

Somehow this error still gets logged, despite everything shutting down correctly...
```
(01/16/2023 17:12:07) [CRI] [netplus] Error in thread pool thread 3: System.Net.Sockets.SocketException (10004): A blocking operation was interrupted by a call to WSACancelBlockingCall.
   at System.Net.Sockets.Socket.ReceiveFrom(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags, EndPoint& remoteEP)
   at System.Net.Sockets.Socket.ReceiveFrom(Byte[] buffer, EndPoint& remoteEP)
   at Celeste.Mod.CelesteNet.Server.UDPReceiverRole.Worker.StartWorker(Socket socket, CancellationToken token) in C:\Program Files (x86)\Steam\steamapps\common\Celeste\Mods\CelesteNet_dev\CelesteNet.Server\ConPlus\UDPReceiverRole.cs:line 29
   at Celeste.Mod.CelesteNet.Server.MultipleSocketBinderRole.RoleWorker.StartWorker(CancellationToken token) in C:\Program Files (x86)\Steam\steamapps\common\Celeste\Mods\CelesteNet_dev\CelesteNet.Server\ConPlus\MultipleSocketBinderRole.cs:line 18
   at Celeste.Mod.CelesteNet.Server.NetPlusThread.ThreadLoop() in C:\Program Files (x86)\Steam\steamapps\common\Celeste\Mods\CelesteNet_dev\CelesteNet.Server\NetPlus\ThreadPool.cs:line 196
```

I have no idea if this breaks anything in how the server actually runs; I only went by testing /api/shutdown 🙂 

- moved the RWLock.Dispose calls outside of a use of the lock
- made RWLock.Inner private because noone should be touching that directly anyways
- properly cancel threads on shutdown(?)