### PR TITLE
Make AddChannels use its Color parameter

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -207,7 +207,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             void AddChannel(ref List<Blob> list, DataChannelList.Channel channel, Color color, float scaleFactorHeader, float scaleFactor, LocationModes locationMode) {
                 list.Add(new() {
                     Name = channel.Name,
-                    Color = ColorChannelHeader,
+                    Color = color,
                     ScaleFactor = scaleFactorHeader,
                     CanSplit = channel != own
                 });


### PR DESCRIPTION
The nested `AddChannel` function in `RebuildListChannels` has a `Color` parameter, but it never gets used.
*(I assume it's supposed to go where `ColorChannelHeader` is)*
https://github.com/0x0ade/CelesteNet/blob/187ef069463d764990d8134e5e293c7f78788b76/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs#L207-L222
I assume the <kbd>CTRL</kbd>+<kbd>C</kbd>, <kbd>CTRL</kbd>+<kbd>V</kbd> programming socks were a tad too strong 😀
It doesn't make much of a difference but at least it works properly now.