### PR TITLE
Remove duplicate/superfluous data being sent in new session handshake.

### DIFF
--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -201,12 +201,6 @@ namespace Celeste.Mod.CelesteNet.Server {
                         Con.Send(fragBlob);
                         avaSendsNew++;
                     }
-
-                    foreach (DataType bound in Server.Data.GetBoundRefs(otherInfo))
-                        if (!bound.Is<MetaPlayerPrivateState>(Server.Data) || other.Channel.ID == 0) {
-                            Con.Send(bound);
-                            boundSends++;
-                        }
                 }
 
             Logger.Log(LogLevel.VVV, "playersession", $"Session #{SessionID} - Done using ConLock -- blobSendsNew/avaSendsNew {blobSendsNew}/{avaSendsNew} - blobSendsOut/avaSendsOut {blobSendsOut}/{avaSendsOut} - boundSends {boundSends}");


### PR DESCRIPTION
These get sent for the appropriate channel by `ResendPlayerStates()` too and so don't really need to be sent for 'main' in an unconditional and fixed way up here.

![image](https://user-images.githubusercontent.com/1682215/215169060-321751f2-25a2-49bc-b9d4-fcb5b98de938.png)

Either line 214 or 215 above will cause a `ResendPlayerStates()`, indirectly or directly. And that will send non-private-state `BoundRefs` (usually `playerGraphics` and `playerState` data type packets) about everyone in the same channel, which most often will also be "main" (Default channel, `ID == 0`). 