### PR TITLE
Prioritize users in the same channel (commands like /w, /tp...)

### DIFF
--- a/CelesteNet.Server.ChatModule/ChatCommands.cs
+++ b/CelesteNet.Server.ChatModule/ChatCommands.cs
@@ -177,7 +177,11 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
 
                 using (Env.Chat.Server.ConLock.R())
                     return
+                        // check for exact name
                         Env.Chat.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.Equals(String, StringComparison.InvariantCultureIgnoreCase) ?? false) ??
+                        // check for partial name in channel
+                        Env.Session?.Channel.Players.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(String, StringComparison.InvariantCultureIgnoreCase) ?? false) ??
+                        // check for partial name elsewhere
                         Env.Chat.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(String, StringComparison.InvariantCultureIgnoreCase) ?? false);
             }
         }


### PR DESCRIPTION
Using a command with an incomplete name *(for example `/tp Sn`)*, if there are at least 2 users whose name begins with `Sn`, the server will pick one at random and use that.
This PR will cause `ChatCMDArg.Session` to first search in the user's channel for a match, and then elsewhere.