### PR TITLE
Sanitize chat messages

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -380,7 +380,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 _RepeatIndex = 0;
                 _Time = 0;
 
-            } else if (!char.IsControl(c)) {
+            } else if (!char.IsControl(c) && CelesteNetUtils.EnglishFontCharsSet.Contains(c)) {
                 if (CursorIndex == Typing.Length) {
                     // Any other character - append.
                     Typing += c;

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -143,6 +143,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public event Action<ChatModule, DataChat>? OnReceive;
 
         public void Handle(CelesteNetConnection? con, DataChat msg) {
+            msg.Text = msg.Text.Sanitize(null, true);
             if (PrepareAndLog(con, msg, false) == null)
                 return;
 

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -143,7 +143,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public event Action<ChatModule, DataChat>? OnReceive;
 
         public void Handle(CelesteNetConnection? con, DataChat msg) {
-            msg.Text = msg.Text.Sanitize(null, true);
+            // don't dedupe the text messages, they should repeat very rarely
+            msg.Text = msg.Text.Sanitize(null, true, false);
             if (PrepareAndLog(con, msg, false) == null)
                 return;
 

--- a/CelesteNet.Shared/CelesteNetUtils.cs
+++ b/CelesteNet.Shared/CelesteNetUtils.cs
@@ -76,7 +76,7 @@ namespace Celeste.Mod.CelesteNet {
 
         [ThreadStatic]
         private static char[]? sanitizedShared;
-        public static unsafe string Sanitize(this string? value, HashSet<char>? illegal = null, bool space = false) {
+        public static unsafe string Sanitize(this string? value, HashSet<char>? illegal = null, bool space = false, bool dedupe = true) {
             const int buffer = 64;
 
             if (value.IsNullOrEmpty())
@@ -124,7 +124,7 @@ namespace Celeste.Mod.CelesteNet {
                     }
 
                 } else {
-                     if (!space) {
+                    if (!space) {
                         for (int i = value.Length; i > 0; --i) {
                             char c = *from++;
                             if (!EnglishFontCharsSet.Contains(c))
@@ -154,7 +154,9 @@ namespace Celeste.Mod.CelesteNet {
                 if (last == (char*) IntPtr.Zero)
                     return "";
 
-                return StringDedupeStaticContext.ToDedupedString(sanitized, (int) (last - sanitized) + 1);
+                int count = (int) (last - sanitized) + 1;
+
+                return !dedupe ? new(sanitized, 0, count) : StringDedupeStaticContext.ToDedupedString(sanitized, count);
             }
         }
 


### PR DESCRIPTION
Previously the chat messages could include unprintable characters, letting users send blank messages and send commands that "don't work" when previously typing in the wrong keyboard layout.