### PR TITLE
Websocket reduce api polls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,10 @@ root = true
 indent_style = space
 indent_size = 4
 
+[*.js]
+indent_style = space
+indent_size = 2
+
 # https://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
 
 csharp_indent_block_contents = true

--- a/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ChatCMDChannel.cs
@@ -30,7 +30,7 @@ $@"Switch to a different channel.
 To list all public channels, {Chat.Settings.CommandPrefix}{ID}
 To create / join a public channel, {Chat.Settings.CommandPrefix}{ID} channel
 To create / join a private channel, {Chat.Settings.CommandPrefix}{ID} {Channels.PrefixPrivate}channel
-To go back to the default channel, {Chat.Settings.CommandPrefix}{ID} {Chat.Server.Channels.Default.Name}";
+To go back to the default channel, {Chat.Settings.CommandPrefix}{ID} {Channels.NameDefault}";
 
         public override void ParseAndRun(ChatCMDEnv env) {
             CelesteNetPlayerSession? session = env.Session;

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
@@ -29,7 +29,7 @@ const mdc = window["mdc"]; // mdc
 }} UserInfo
  */
 
-export class FrontendPlayersPanel extends FrontendBasicPanel {
+export class FrontendAccountsPanel extends FrontendBasicPanel {
   /**
    * @param {import("../frontend.js").Frontend} frontend
    */

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/chat.js
@@ -14,6 +14,7 @@ const mdc = window["mdc"]; // mdc
 @typedef {{
   ID: number,
   PlayerID: number,
+  Name: string,
   Targets: number[] | null,
   Color: string,
   DateTime: number,
@@ -214,11 +215,11 @@ export class FrontendChatPanel extends FrontendBasicPanel {
 
         if (data.PlayerID) {
           if (data.PlayerID !== this.frontend.MAX_INT) {
-            const player = FrontendPlayersPanel["instance"].data.find(p => p.ID == data.PlayerID);
+            let player = FrontendPlayersPanel["instance"].data.find(p => p.ID == data.PlayerID);
             // TODO: Rerender el on missing player only once! Otherwise render -> refresh -> render -> refresh...
             if (!player)
               FrontendPlayersPanel["instance"].refresh();
-            name = player && player.FullName || ("#" + data.PlayerID);
+            name = player && player.FullName || data.Name || ("#" + data.PlayerID);
 
             opts = [
               ...opts,
@@ -228,6 +229,8 @@ export class FrontendChatPanel extends FrontendBasicPanel {
           } else {
             name = " ** SERVER ** ";
           }
+        } else if (data.Name) {
+          name = data.Name;
         }
 
         if (data.Targets && data.Targets.length > 0 && !data.Tag.startsWith("channel ")) {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/players.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/players.js
@@ -37,6 +37,22 @@ export class FrontendPlayersPanel extends FrontendBasicPanel {
     /** @type {PlayerData[]} */
     this.data = [];
     this.input = null;
+    frontend.sync.register("sess_join", data => this.playerJoin(data));
+    frontend.sync.register("sess_leave", data => this.playerLeave(data));
+  }
+
+  playerJoin(data) {
+    this.data.push(data);
+    this.rebuildList();
+    this.render(null);
+  }
+
+  playerLeave(data) {
+    let idx = this.data.findIndex(p => p.ID == data.ID);
+    if (idx != -1)
+      this.data.splice(idx, 1);
+    this.rebuildList();
+    this.render(null);
   }
 
   render(el) {
@@ -63,7 +79,10 @@ export class FrontendPlayersPanel extends FrontendBasicPanel {
 
   async update() {
     this.data = await fetch(this.ep).then(r => r.json());
+    this.rebuildList();
+  }
 
+  rebuildList() {
     // @ts-ignore
     this.input = this.elInput.getElementsByTagName("input")[0];
     let filter = this.input.value.trim().toLowerCase();

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/players.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/players.js
@@ -42,6 +42,16 @@ export class FrontendPlayersPanel extends FrontendBasicPanel {
   }
 
   playerJoin(data) {
+    data.TCPPingMs = 0;
+    data.UDPPingMs = 0;
+    data.TCPDownlinkBpS = 0;
+    data.TCPDownlinkPpS = 0;
+    data.TCPUplinkBpS = 0;
+    data.TCPUplinkPpS = 0;
+    data.UDPDownlinkBpS = 0;
+    data.UDPDownlinkPpS = 0;
+    data.UDPUplinkBpS = 0;
+    data.UDPUplinkPpS = 0;
     this.data.push(data);
     this.rebuildList();
     this.render(null);
@@ -94,13 +104,13 @@ export class FrontendPlayersPanel extends FrontendBasicPanel {
         ${p.Name}<br>
         ${p.DisplayName !== p.FullName ? p.UID : this.frontend.censor(p.UID)}<br>
         ${this.frontend.censor(p.Connection)}<br>
-        ${el => !p.TCPDownlinkBpS ? rd$(el)`<span></span>` :
+        ${el => 
           rd$(el)`<span>
-            <code>Ping:${` ${p.TCPPingMs ? `${p.TCPPingMs}ms` : '-'} TCP | ${p.UDPPingMs ? `${p.UDPPingMs}ms` : '-'} UDP`}</code><br>
-            <code>TCP ↓:${` ${p.TCPDownlinkBpS.toFixed(3)} BpS | ${p.TCPDownlinkPpS.toFixed(3)} PpS`}</code><br>
-            <code>UDP ↓:${` ${p.UDPDownlinkBpS.toFixed(3)} BpS | ${p.UDPDownlinkPpS.toFixed(3)} PpS`}</code><br>
-            <code>TCP ↑:${` ${p.TCPUplinkBpS.toFixed(3)} BpS | ${p.TCPUplinkPpS.toFixed(3)} PpS`}</code><br>
-            <code>UDP ↑:${` ${p.UDPUplinkBpS.toFixed(3)} BpS | ${p.UDPUplinkPpS.toFixed(3)} PpS`}</code>
+            <code>Ping:${` ${ p.TCPPingMs      ? `${p.TCPPingMs}ms` : '-'} TCP | ${p.UDPPingMs ? `${p.UDPPingMs}ms` : '-'} UDP`}</code><br>
+            <code>TCP ↓:${` ${p.TCPDownlinkBpS ? `${p.TCPDownlinkBpS.toFixed(3)} BpS` : '-'} | ${p.TCPDownlinkPpS ? `${p.TCPDownlinkPpS.toFixed(3)} PpS` : '-'}`}</code><br>
+            <code>UDP ↓:${` ${p.UDPDownlinkBpS ? `${p.UDPDownlinkBpS.toFixed(3)} BpS` : '-'} | ${p.UDPDownlinkPpS ? `${p.UDPDownlinkPpS.toFixed(3)} PpS` : '-'}`}</code><br>
+            <code>TCP ↑:${` ${p.TCPUplinkBpS ? `${p.TCPUplinkBpS.toFixed(3)} BpS` : '-'} | ${p.TCPUplinkPpS ? `${p.TCPUplinkPpS.toFixed(3)} PpS` : '-'}`}</code><br>
+            <code>UDP ↑:${` ${p.UDPUplinkBpS ? `${p.UDPUplinkBpS.toFixed(3)} BpS` : '-'} | ${p.UDPUplinkPpS ? `${p.UDPUplinkPpS.toFixed(3)} PpS` : '-'}`}</code>
           </span>`}
         </span>`
       )(el);

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -162,7 +162,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         }
 
         private void OnCreateChannel(Channel channel, int total) {
-            BroadcastCMD(false, "chan_create", new { Channel = new { channel.ID, channel.Name, channel.IsPrivate, Players = channel.Players.Select(p => p.SessionID) }, Count = total });
+            BroadcastCMD(channel.IsPrivate, "chan_create", new { Channel = new { channel.ID, channel.Name, channel.IsPrivate, Players = channel.Players.Select(p => p.SessionID) }, Count = total });
         }
 
         private void OnRemoveChannel(string name, uint id, int total) {

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -138,14 +138,14 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         private void OnSessionStart(CelesteNetPlayerSession session) {
             BroadcastCMD(false, "sess_join", PlayerSessionToFrontend(session, shorten: true));
             TryBroadcastUpdate(Settings.APIPrefix + "/status");
-            TryBroadcastUpdate(Settings.APIPrefix + "/players");
+            //TryBroadcastUpdate(Settings.APIPrefix + "/players");
             session.OnEnd += OnSessionEnd;
         }
 
         private void OnSessionEnd(CelesteNetPlayerSession session, DataPlayerInfo? lastPlayerInfo) {
             BroadcastCMD(false, "sess_leave", PlayerSessionToFrontend(session, shorten: true));
             TryBroadcastUpdate(Settings.APIPrefix + "/status");
-            TryBroadcastUpdate(Settings.APIPrefix + "/players");
+            //TryBroadcastUpdate(Settings.APIPrefix + "/players");
         }
 
         private void OnDisconnect(CelesteNetServer server, CelesteNetConnection con, CelesteNetPlayerSession? session) {
@@ -157,12 +157,12 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             TryBroadcastUpdate(Settings.APIPrefix + "/channels");
         }
 
-        private void OnChannelMove(CelesteNetPlayerSession session, Channel? from, Channel to) {
-            BroadcastCMD(false, "chan_move", new { session.SessionID, session.UID, fromID = from?.ID, toID = to.ID });
+        private void OnChannelMove(CelesteNetPlayerSession session, Channel? from, Channel? to) {
+            BroadcastCMD(false, "chan_move", new { session.SessionID, session.UID, fromID = from?.ID, toID = to?.ID });
         }
 
         private void OnCreateChannel(Channel channel, int total) {
-            BroadcastCMD(false, "chan_create", new { channel.Name, channel.ID, channel.IsPrivate, Count = total });
+            BroadcastCMD(false, "chan_create", new { Channel = new { channel.ID, channel.Name, channel.IsPrivate, Players = channel.Players.Select(p => p.SessionID) }, Count = total });
         }
 
         private void OnRemoveChannel(string name, uint id, int total) {

--- a/CelesteNet.Server.FrontendModule/FrontendUtils.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendUtils.cs
@@ -27,6 +27,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             => new {
                 msg.ID,
                 PlayerID = msg.Player?.ID ?? uint.MaxValue,
+                Name = msg.Player?.FullName ?? string.Empty,
                 Targets = msg.Targets?.Select(p => p?.ID ?? uint.MaxValue) ?? null,
                 Color = msg.Color.ToHex(),
                 DateTime = msg.Date.ToUnixTime(),

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -350,29 +350,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
             object responseObj;
             using (f.Server.ConLock.R()) {
-                responseObj = f.Server.PlayersByID.Values.Select(p => new {
-                    ID = p.SessionID,
-                    UID = auth ? p.UID : null,
-                    p.PlayerInfo?.Name,
-                    p.PlayerInfo?.FullName,
-                    p.PlayerInfo?.DisplayName,
-                    Avatar = f.Server.UserData.HasFile(p.UID, "avatar.png") ? $"{f.Settings.APIPrefix}/avatar?uid={p.UID}" : null,
-
-                    Connection = auth ? p.Con.ID : null,
-                    ConnectionUID = auth ? p.Con.UID : null,
-
-                    TCPPingMs = auth ? (p.Con as ConPlusTCPUDPConnection)?.TCPPingMs : null,
-                    UDPPingMs = auth ? (p.Con as ConPlusTCPUDPConnection)?.UDPPingMs : null,
-
-                    TCPDownlinkBpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.TCPRecvRate.ByteRate : null,
-                    TCPDownlinkPpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.TCPRecvRate.PacketRate : null,
-                    TCPUplinkBpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.TCPSendRate.ByteRate : null,
-                    TCPUplinkPpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.TCPSendRate.PacketRate : null,
-                    UDPDownlinkBpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.UDPRecvRate.ByteRate : null,
-                    UDPDownlinkPpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.UDPRecvRate.PacketRate : null,
-                    UDPUplinkBpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.UDPSendRate.ByteRate : null,
-                    UDPUplinkPpS = auth ? (p.Con as ConPlusTCPUDPConnection)?.UDPSendRate.PacketRate : null,
-                }).ToArray();
+                responseObj = f.Server.PlayersByID.Values.Select(p => f.PlayerSessionToFrontend(p, auth)).ToArray();
             }
             f.RespondJSON(c, responseObj);
         }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
@@ -13,7 +13,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
     public class WSCMDDissolve : WSCMD<uint> {
         public override bool MustAuth => true;
         public override object? Run(uint input) {
-            if (input == 0)
+            if (input == Channels.IdDefault)
                 return null;
 
             ChatModule chat = Frontend.Server.Get<ChatModule>();
@@ -22,7 +22,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             lock (channels.All)
                 if (channels.ByID.TryGetValue(input, out Channel? c))
                     foreach (CelesteNetPlayerSession player in c.Players.ToArray()) {
-                        channels.Move(player, channels.Default.Name);
+                        channels.Move(player, Channels.NameDefault);
                         chat.SendTo(player, $"{c.Name} dissolved by server admin.", color: chat.Settings.ColorCommandReply);
                     }
             return null;

--- a/CelesteNet.Server/Channels.cs
+++ b/CelesteNet.Server/Channels.cs
@@ -14,6 +14,7 @@ namespace Celeste.Mod.CelesteNet.Server {
     public class Channels : IDisposable {
 
         public const string NameDefault = "main";
+        public const uint IdDefault = 0;
         public const string NamePrivate = "!<private>";
         public const string PrefixPrivate = "!";
 
@@ -84,6 +85,13 @@ namespace Celeste.Mod.CelesteNet.Server {
 
         public Action<Channels>? OnBroadcastList;
 
+        // the integer will be the current number of channels to try and detect getting out of sync
+        public Action<Channel, int>? OnCreate;
+        // On removal this only gives the Name & ID of the removed channel, plus total count as above
+        public Action<string, uint, int>? OnRemove;
+
+        public Action<CelesteNetPlayerSession, Channel?, Channel>? OnMove;
+
         public void BroadcastList() {
             using (ListSnapshot<Channel> snapshot = All.ToSnapshot())
                 foreach (Channel c in snapshot)
@@ -131,6 +139,7 @@ namespace Celeste.Mod.CelesteNet.Server {
                     foreach (CelesteNetPlayerSession other in prev.Players)
                         other.Con.Send(move);
 
+                OnMove?.Invoke(session, prev, c);
                 BroadcastList();
 
                 session.ResendPlayerStates();
@@ -173,6 +182,9 @@ namespace Celeste.Mod.CelesteNet.Server {
                 Ctx.All.Add(this);
                 Ctx.ByName[Name] = this;
                 Ctx.ByID[ID] = this;
+                // only invoke this for player-created channels, not "main"
+                if (ID != Channels.IdDefault)
+                    Ctx.OnCreate?.Invoke(this, Ctx.All.Count);
             }
         }
 
@@ -207,13 +219,14 @@ namespace Celeste.Mod.CelesteNet.Server {
             // Hopefully nobody will get stuck in channel limbo...
             session.OnEnd -= RemoveByDC;
 
-            if (ID == 0)
+            if (ID == Channels.IdDefault)
                 return;
 
             lock (Ctx.All) {
                 if (Players.Count > 0)
                     return;
 
+                Ctx.OnRemove?.Invoke(Name, ID, Ctx.All.Count);
                 Ctx.All.Remove(this);
                 Ctx.ByName.Remove(Name);
                 Ctx.ByID.Remove(ID);


### PR DESCRIPTION
When people are reconnecting a lot because of unstable connections or high server load, the Websocket constantly sends out commands like `"cmd update /api/..."` prompting the listeners to poll the HTTP endpoints for all `/players`, `/channels` and `/status` infos over and over, sometimes dozens of times a second.

In this PR I'm trying to add a sort of cooldown / rate-limit on these commands since they're not "critical" in that they're just prompting the frontend to reload its panels because the state of things may have changed.

The cooldowns are per-path so that the unlikely event doesn't happen where one of them like `/api/status` gets completely locked out from being sent because the others are more frequent. Probably unnecessary?

I'm also adding more stuff to the actual websocket updates that get sent out, namely for informing listeners about joining/leaving player **sessions**, new/removed **channels** and channel **moves**. 
I'm also adding the `Name` to the `"cmd chat"` websocket data because I would often get messages before/without knowing the `Name` of the sender and just having the session `ID`.

~~Making this a draft because I still need to actually make the Frontend implement the new Websocket commands.~~

Not a draft anymore because I think I got it all implemented?

This adds these new Websocket "cmd" commands:
 - "cmd **sess_join** { ... }" -> sends a shorter version of the player object in /players EP, without the connection info like ping etc. (because this is a brand new connection anyways)
 - "cmd **sess_leave** { ... }" -> same as above, namely just `{ ID = p.SessionID, UID, Name, FullName, DisplayName, Avatar, Connection, ConnectionUID }`
 - "cmd **chan_move** { ... }" -> `{ SessionID, UID, fromID, toID }` where `fromID` and `toID` can be null to indicate newly joined/disconnected
 - "cmd **chan_create** { ... }" -> `{ Channel = new { ID, Name, IsPrivate, Players = [ p.SessionID, ... ] }, Count }` - pretty much same as in /channels EP for `Channel` and `Count` is the total number of channels after this creation, to give clients a chance to catch desync and poll the API EPs
  - "cmd **chan_remove** { ... }" -> `{ Name, ID, Count }` - just name/ID here, and Count same reasons as above

