### PR TITLE
Give DateTime.ToUnixTime a more descriptive name

### DIFF
--- a/CelesteNet.Server.FrontendModule/FrontendUtils.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendUtils.cs
@@ -29,13 +29,13 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 PlayerID = msg.Player?.ID ?? uint.MaxValue,
                 Targets = msg.Targets?.Select(p => p?.ID ?? uint.MaxValue) ?? null,
                 Color = msg.Color.ToHex(),
-                DateTime = msg.Date.ToUnixTime(),
+                DateTime = msg.Date.ToUnixTimeMillis(),
                 msg.Tag,
                 msg.Text
             };
 
         private static readonly DateTime UnixTimeStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        public static double ToUnixTime(this DateTime time)
+        public static double ToUnixTimeMillis(this DateTime time)
             => time.Subtract(UnixTimeStart).TotalMilliseconds;
 
     }

--- a/CelesteNet.Server.FrontendModule/FrontendUtils.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendUtils.cs
@@ -36,7 +36,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
         private static readonly DateTime UnixTimeStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         public static double ToUnixTime(this DateTime time)
-            => time.Subtract(UnixTimeStart).TotalSeconds;
+            => time.Subtract(UnixTimeStart).TotalMilliseconds;
 
     }
 }

--- a/CelesteNet.Server.FrontendModule/FrontendUtils.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendUtils.cs
@@ -36,7 +36,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
         private static readonly DateTime UnixTimeStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         public static double ToUnixTime(this DateTime time)
-            => time.Subtract(UnixTimeStart).TotalMilliseconds;
+            => time.Subtract(UnixTimeStart).TotalSeconds;
 
     }
 }

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -254,7 +254,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             bool auth = f.IsAuthorized(c);
             lock (StatLock)
                 f.RespondJSON(c, new {
-                    StartupTime = f.Server.StartupTime.ToUnixTime(),
+                    StartupTime = f.Server.StartupTime.ToUnixTimeMillis(),
                     GCMemory = GC.GetTotalMemory(false),
                     Modules = f.Server.Modules.Count,
                     TickRate = f.Server.CurrentTickRate,
@@ -321,12 +321,12 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                     Ban = ban.Reason.IsNullOrEmpty() ? null : new {
                         ban.Name,
                         ban.Reason,
-                        From = ban.From?.ToUnixTime() ?? 0,
-                        To = ban.To?.ToUnixTime() ?? 0
+                        From = ban.From?.ToUnixTimeMillis() ?? 0,
+                        To = ban.To?.ToUnixTimeMillis() ?? 0
                     },
                     Kicks = kicks.Log.Select(e => new {
                         e.Reason,
-                        From = e.From?.ToUnixTime() ?? 0
+                        From = e.From?.ToUnixTimeMillis() ?? 0
                     }).ToArray()
                 };
             }).ToArray());


### PR DESCRIPTION
The extension method `DateTime.ToUnixTime()` returns `ms`, not `s` as expected of Unix time.
Renaming the function will reduce confusion.