### PR TITLE
Give clients an option to disable avatars entirely. A bit hacky.

### DIFF
--- a/CelesteNet.Client/CelesteNetClient.cs
+++ b/CelesteNet.Client/CelesteNetClient.cs
@@ -52,6 +52,8 @@ namespace Celeste.Mod.CelesteNet.Client {
             Settings = settings;
             Options = options;
 
+            Options.AvatarsDisabled = !Settings.ReceivePlayerAvatars;
+
             Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClient created");
 
             Data = new();
@@ -299,6 +301,12 @@ namespace Celeste.Mod.CelesteNet.Client {
             // The first DataPlayerInfo sent from the server is our own
             if (PlayerInfo == null || PlayerInfo.ID == info.ID)
                 PlayerInfo = info;
+        }
+
+        public bool Filter(CelesteNetConnection con, DataPlayerInfo info) {
+            if (info != null && Options.AvatarsDisabled)
+                info.DisplayName = info.FullName;
+            return true;
         }
 
         public void Handle(CelesteNetConnection con, DataReady ready) {

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -41,6 +41,9 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public bool AutoReconnect { get; set; } = true;
 
+        [SettingSubText("modoptions_celestenetclient_avatarshint")]
+        public bool ReceivePlayerAvatars { get; set; } = true;
+
 #if !DEBUG
         [SettingIgnore]
 #endif
@@ -268,6 +271,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                 (EnabledEntry = new TextMenu.OnOff("modoptions_celestenetclient_connected".DialogClean(), Connected))
                 .Change(v => Connected = v)
             );
+            EnabledEntry.AddDescription(menu, "modoptions_celestenetclient_connectedhint".DialogClean());
         }
 
         public void CreateServerEntry(TextMenu menu, bool inGame) {

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MDraw = Monocle.Draw;
 
@@ -35,6 +36,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public List<CommandInfo> CommandList = new();
         public Dictionary<string, string> CommandAliasLookup = new();
+
+        protected Regex AvatarRegex = new Regex(@":celestenet_avatar_\d+_:", RegexOptions.Compiled);
 
         public ChatMode Mode => Active ? ChatMode.All : Settings.ShowNewMessages;
 
@@ -251,6 +254,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         public void Handle(CelesteNetConnection con, DataChat msg) {
             if (Client == null)
                 return;
+
+            if (Client.Options.AvatarsDisabled) {
+                msg.Text = AvatarRegex.Replace(msg.Text, "");
+                msg.Tag = AvatarRegex.Replace(msg.Tag, "");
+            }
 
             lock (Log) {
                 if (msg.Player?.ID == Client.PlayerInfo?.ID) {

--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -201,9 +201,11 @@ namespace Celeste.Mod.CelesteNet.Server {
 
                     Con.Send(otherInfo);
                     blobSendsNew++;
-                    foreach (DataInternalBlob fragBlob in other.AvatarFragments) {
-                        Con.Send(fragBlob);
-                        avaSendsNew++;
+                    if (!ClientOptions.AvatarsDisabled) {
+                        foreach (DataInternalBlob fragBlob in other.AvatarFragments) {
+                            Con.Send(fragBlob);
+                            avaSendsNew++;
+                        }
                     }
                 }
 

--- a/CelesteNet.Shared/CelesteNetClientOptions.cs
+++ b/CelesteNet.Shared/CelesteNetClientOptions.cs
@@ -1,5 +1,6 @@
 namespace Celeste.Mod.CelesteNet {
     public class CelesteNetClientOptions {
         public bool IsReconnect;
+        public bool AvatarsDisabled = false;
     }
 }

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -24,6 +24,8 @@
 # GhostNet Module Options
 	MODOPTIONS_CELESTENETCLIENT_TITLE= 			CelesteNet - Multiplayer
 	MODOPTIONS_CELESTENETCLIENT_CONNECTED=			Connected
+	MODOPTIONS_CELESTENETCLIENT_CONNECTEDHINT=			Try setting "Receive Player Avatars" OFF if you can't connect
+	MODOPTIONS_CELESTENETCLIENT_AVATARSHINT=			Tells the server not to send you any profile pics during handshake.
 	MODOPTIONS_CELESTENETCLIENT_SERVER=			Server: ((server))
 	MODOPTIONS_CELESTENETCLIENT_NAME=			Name / Key: ((name))
 	MODOPTIONS_CELESTENETCLIENT_SETTINGS=			Settings


### PR DESCRIPTION
What it says above. Hopefully this'll help some players connect to a somewhat overloaded server?

In the future we should really consider moving some of the avatar sending to after DataReady, because we already had issues with this filling up a 1024 item send queue.

The other option would be to go with HTTP requests and let the client fetch avatars itself.