### PR TITLE
Fix player list not resizing when changing "UI Scale: Player List" slider

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -12,7 +12,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public static event Action<BlobPlayer, DataPlayerState> OnGetState;
 
-        public float Scale => Settings.UIScale;
+        public float Scale => Settings.UIScalePlayerList;
         private float LastScale;
 
         public readonly Color ColorCountHeader = Calc.HexToColor("FFFF77");


### PR DESCRIPTION
Self-explanatory.
The player list used `UIScale` as its scale factor instead of `UIScalePlayerList`.