### PR TITLE
Add the ability to hide your own channel name

### DIFF
--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -44,6 +44,9 @@ namespace Celeste.Mod.CelesteNet.Client {
         [SettingSubText("modoptions_celestenetclient_avatarshint")]
         public bool ReceivePlayerAvatars { get; set; } = true;
 
+        [SettingSubText("modoptions_celestenetclient_hideownchannelhint")]
+        public bool HideOwnChannelName { get; set; } = false;
+
 #if !DEBUG
         [SettingIgnore]
 #endif

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 using MDraw = Monocle.Draw;
 
 namespace Celeste.Mod.CelesteNet.Client.Components {
@@ -197,7 +198,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 };
 
                 DataChannelList.Channel channel = Channels.List.FirstOrDefault(c => c.Players.Contains(player.ID));
-                if (channel != null && !string.IsNullOrEmpty(channel.Name) && !(Settings.HideOwnChannelName && channel == own))
+                if (!string.IsNullOrEmpty(channel?.Name) && !(Settings.HideOwnChannelName && channel == own))
                     blob.Name += $" #{channel.Name}";
 
                 if (Client.Data.TryGetBoundRef(player, out DataPlayerState state))

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -89,6 +89,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         public bool AllowSplit => Settings.PlayerListAllowSplit;
         private bool LastAllowSplit;
 
+        public bool HideOwnChannelName => Settings.HideOwnChannelName;
+        private bool LastHideOwnChannelName;
+
         private static float? spaceWidth;
         protected static float SpaceWidth {
             get {
@@ -192,7 +195,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 };
 
                 DataChannelList.Channel channel = Channels.List.FirstOrDefault(c => c.Players.Contains(player.ID));
-                if (channel != null && !string.IsNullOrEmpty(channel.Name))
+                if (channel != null && !string.IsNullOrEmpty(channel.Name) && !Settings.HideOwnChannelName)
                     blob.Name += $" #{channel.Name}";
 
                 if (Client.Data.TryGetBoundRef(player, out DataPlayerState state))
@@ -250,9 +253,10 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             DataChannelList.Channel own = Channels.List.FirstOrDefault(c => c.Players.Contains(Client.PlayerInfo.ID));
 
             void AddChannel(ref List<Blob> list, DataChannelList.Channel channel, Color color, float scaleFactorHeader, float scaleFactor, LocationModes locationMode) {
+                bool hideChannel = channel == own && channel.Name != "main" && Settings.HideOwnChannelName;
                 list.Add(new() {
-                    Name = channel.Name,
-                    Color = color,
+                    Name = hideChannel ? "<hidden>" : channel.Name,
+                    Color = hideChannel ? ColorChannelHeaderPrivate : color,
                     ScaleFactor = scaleFactorHeader,
                     CanSplit = channel != own
                 });
@@ -603,12 +607,14 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 LastShowPing != ShowPing ||
                 LastAllowSplit != AllowSplit ||
                 LastScale != Scale ||
+                LastHideOwnChannelName != HideOwnChannelName ||
                 ShouldRebuild) {
                 LastListMode = ListMode;
                 LastLocationMode = LocationMode;
                 LastShowPing = ShowPing;
                 LastAllowSplit = AllowSplit;
                 LastScale = Scale;
+                LastHideOwnChannelName = HideOwnChannelName;
                 ShouldRebuild = false;
                 RebuildList();
             }

--- a/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetPlayerListComponent.cs
@@ -184,6 +184,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         public void RebuildListClassic(ref List<Blob> list, ref DataPlayerInfo[] all) {
+            DataChannelList.Channel own = Channels.List.FirstOrDefault(c => c.Players.Contains(Client.PlayerInfo.ID));
+
             foreach (DataPlayerInfo player in all.OrderBy(p => GetOrderKey(p))) {
                 if (string.IsNullOrWhiteSpace(player.DisplayName))
                     continue;
@@ -195,7 +197,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 };
 
                 DataChannelList.Channel channel = Channels.List.FirstOrDefault(c => c.Players.Contains(player.ID));
-                if (channel != null && !string.IsNullOrEmpty(channel.Name) && !Settings.HideOwnChannelName)
+                if (channel != null && !string.IsNullOrEmpty(channel.Name) && !(Settings.HideOwnChannelName && channel == own))
                     blob.Name += $" #{channel.Name}";
 
                 if (Client.Data.TryGetBoundRef(player, out DataPlayerState state))

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -26,6 +26,8 @@
 	MODOPTIONS_CELESTENETCLIENT_CONNECTED=			Connected
 	MODOPTIONS_CELESTENETCLIENT_CONNECTEDHINT=			Try setting "Receive Player Avatars" OFF if you can't connect
 	MODOPTIONS_CELESTENETCLIENT_AVATARSHINT=			Tells the server not to send you any profile pics during handshake.
+	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNEL=			Hide your channel name
+	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNELHINT=		Intended for streamers.{n}Prevents leaking your channel name when receiving a message or opening the player list.
 	MODOPTIONS_CELESTENETCLIENT_SERVER=			Server: ((server))
 	MODOPTIONS_CELESTENETCLIENT_NAME=			Name / Key: ((name))
 	MODOPTIONS_CELESTENETCLIENT_SETTINGS=			Settings


### PR DESCRIPTION
This feature is mainly intended for streamers.
This prevents the viewers from seeing the channel the streamer is in and joining it. *(unless they join `main`)*
The channel name is hidden from both the tab list and chat messages *(commands included)*.
The only place it's not hidden is in the chat buffer and messages that are on their way to the server. Not like a streamer would want to switch channels on stream anyway.

Heard someone suggesting this would be a good idea, so why not?