### PR TITLE
Fix status WSCMD not broadcasting

### DIFF
--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDStatus.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDStatus.cs
@@ -32,6 +32,8 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             if (data.Spin is bool spin)
                 status.Spin = spin;
 
+            Frontend.Server.BroadcastAsync(status);
+
             return null;
         }
     }


### PR DESCRIPTION
When the WebSocket "status" command payload is not a string, the server status object gets created, but never gets broadcast.
https://github.com/0x0ade/CelesteNet/blob/cd6c5f1c671adf44e60c776f4f5566908c6f3ff0/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDStatus.cs#L15-L36
`Frontend.Server.BroadcastAsync` gets completely omitted past the `input is string` check.