### PR TITLE
Fix moderator/admin key leakage

### DIFF
--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
@@ -175,6 +175,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         [RCEndpoint(false, "/userinfo", "?uid={uid}&key={keyIfNoUID}", "", "User Info", "Get some basic user info.")]
         public static void UserInfo(Frontend f, HttpRequestEventArgs c) {
             bool auth = f.IsAuthorized(c);
+            bool usedOwnKey = false;
 
             NameValueCollection args = f.ParseQueryString(c.Request.RawUrl);
 
@@ -201,6 +202,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 }
 
                 auth = true;
+                usedOwnKey = true;
             }
 
             if (uid.IsNullOrEmpty()) {
@@ -212,6 +214,10 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             }
 
             BasicUserInfo info = f.Server.UserData.Load<BasicUserInfo>(uid);
+
+            // prevent leaking other moderator and admin keys when using a session
+            if (!usedOwnKey && info.Tags.Intersect(BasicUserInfo.AUTH_TAGS).Any() && !f.IsAuthorizedExec(c))
+                auth = false;
 
             f.RespondJSON(c, new {
                 UID = uid,

--- a/CelesteNet.Server/UserData.cs
+++ b/CelesteNet.Server/UserData.cs
@@ -72,6 +72,11 @@ namespace Celeste.Mod.CelesteNet.Server {
     public class BasicUserInfo {
         public static readonly string TAG_AUTH = "moderator";
         public static readonly string TAG_AUTH_EXEC = "admin";
+        public static readonly IReadOnlyList<string> AUTH_TAGS = new List<string>() {
+            TAG_AUTH,
+            TAG_AUTH_EXEC
+        }.AsReadOnly();
+
         public string Name { get; set; } = "";
         // TODO: Move into separate Discord module!
         public string Discrim { get; set; } = "";


### PR DESCRIPTION
By getting a control panel session *(exec or not)*, requesting user data via `/api/userinfo?uid=...` *(where `uid` is a moderator or admin Discord user ID)* with said session causes the API to leak sensitive moderator/admin keys. This obviously allows for privilege escalation or impersonation. The `/cp` control panel does not exhibit that behavior.

This pull request will hide keys if their owners have a tag in the `BasicUserInfo.AUTH_TAGS` list. The endpoint will still share keys if the session is an exec one or if the user provided the user key themselves.