### PR TITLE
Fill missing return statements

### DIFF
--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -492,8 +492,10 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 #if NETCORE
         [RCEndpoint(true, "/exec", "", "", "Execute C#", "Run some C# code. Highly dangerous!")]
         public static void Exec(Frontend f, HttpRequestEventArgs c) {
-            if (!f.IsAuthorizedExec(c))
+            if (!f.IsAuthorizedExec(c)) {
                 f.Respond(c, "Unauthorized!");
+                return;
+            }
 
             ExecALC? alc = null;
 

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
@@ -241,6 +241,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 f.RespondJSON(c, new {
                     Error = "Unauthorized - invalid key."
                 });
+                return;
             }
 
             f.Server.UserData.RevokeKey(key);


### PR DESCRIPTION
Some API endpoints lacked a `return;` statement after sending a response. One example would be in `/exec`:
https://github.com/0x0ade/CelesteNet/blob/22612a92e1d8abb13e871e35bf1a47d24157457f/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs#L493-L498

The function does not exit after determining the request lacks authorization, potentially allowing for privilege escalation and running C# code as a moderator. The server will also attempt to respond to a request twice, throwing an exception.
###### *(also the status code is still 200 OK, when it should be 401 Unauthorized)*

In practice, however, because the response has already been replied to, the request input stream somehow gets cleared out and the build always fails with a missing entry point due to the code being empty.
```
(04/22/2023 01:19:40) [DEV] [frontend-exec] System.Exception: Failed building:
CS5001: Program does not contain a static 'Main' method suitable for an entry point
   at Celeste.Mod.CelesteNet.Server.Control.RCEndpoints.Exec(Frontend f, HttpRequestEventArgs c)
```
The double response exception is caught in the frontend module fortunately, and does not absolutely murder the server.
```
(04/22/2023 01:19:40) [ERR] [frontend] Frontend failed responding: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'WebSocketSharp.Net.HttpListenerResponse'.
   at WebSocketSharp.Net.HttpListenerResponse.checkDisposedOrHeadersSent()
   at WebSocketSharp.Net.HttpListenerResponse.set_StatusCode(Int32 value)
   at Celeste.Mod.CelesteNet.Server.Control.RCEndpoints.Exec(Frontend f, HttpRequestEventArgs c)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at Celeste.Mod.CelesteNet.Server.Control.Frontend.<>c__DisplayClass13_0.<Init>b__0(Frontend f, HttpRequestEventArgs c)
   at Celeste.Mod.CelesteNet.Server.Control.Frontend.HandleRequest(HttpRequestEventArgs c)
   at Celeste.Mod.CelesteNet.Server.Control.Frontend.HandleRequestRaw(Object sender, HttpRequestEventArgs c)
```
----
Another unintentional case is in `/revokekey`:
https://github.com/0x0ade/CelesteNet/blob/22612a92e1d8abb13e871e35bf1a47d24157457f/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs#L238-L244

Fortunately this does not do anything for invalid keys. *(other than log error for responding twice, like in the above example)*