### PR TITLE
Add and correct response status codes

### DIFF
--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -407,6 +407,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
             if (!f.IsAuthorizedExec(c)) {
                 if (moduleID == f.Wrapper.ID || f.Settings.ExecOnlySettings.Contains(moduleID)) {
+                    c.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
                     f.Respond(c, "Unauthorized!");
                     return;
                 }
@@ -438,6 +439,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                     });
                     return;
                 } catch (Exception e) {
+                    c.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
                     f.RespondJSON(c, new {
                         Error = e.ToString()
                     });
@@ -466,6 +468,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                     });
                     return;
                 } catch (Exception e) {
+                    c.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
                     f.RespondJSON(c, new {
                         Error = e.ToString()
                     });
@@ -482,6 +485,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 text = File.ReadAllText(path);
                 f.Respond(c, text);
             } catch (Exception e) {
+                c.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
                 f.RespondJSON(c, new {
                     Error = e.ToString()
                 });
@@ -492,8 +496,10 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 #if NETCORE
         [RCEndpoint(true, "/exec", "", "", "Execute C#", "Run some C# code. Highly dangerous!")]
         public static void Exec(Frontend f, HttpRequestEventArgs c) {
-            if (!f.IsAuthorizedExec(c))
+            if (!f.IsAuthorizedExec(c)) {
+                c.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
                 f.Respond(c, "Unauthorized!");
+            }
 
             ExecALC? alc = null;
 
@@ -561,7 +567,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
             } catch (Exception e) {
                 Logger.Log(LogLevel.DEV, "frontend-exec", e.ToString());
-                c.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
+                c.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
                 f.Respond(c, $"Error:\n{e}");
 
             } finally {


### PR DESCRIPTION
Some responses don't have their status code set, defaulting to `200 OK`, despite there being a problem.