### PR TITLE
Ability for Tab Suggestions to be canceled/hidden

### DIFF
--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -420,6 +420,8 @@ namespace Celeste.Mod.CelesteNet.Client {
 
             public bool ShowScrollingControls { get; set; } = true;
 
+            public bool ChatCloseCancelsSuggestions { get; set; } = true;
+
             [SettingIgnore]
             [SettingRange(4, 16)]
             public int ChatLogLength { get; set; } = 8;


### PR DESCRIPTION
Either when switching input history entries (was currently broken by suggestions popping in right away stopping you from navigating further up the history)
Or also canceling suggestions first by pressing Escape and only closing chat on the next press (has an On/Off setting)

Different "modes" of hiding Suggestions:
 - enum CompletionHiddenBy
    - None
    -> everything functions normally, completion suggestions get updated
    - RepeatIndex
    -> keep them hidden after navigating up/down the input history -- most input changes like typing, backspace will make it update again
    - ChatClosePressed
    -> the setting is on to not immediately close chat on Escape (or chat close keybind), in this state moving the cursor or typing/backspace won't return to CompletionHiddenBy.None -- only does this when user presses Tab or Space