### PR TITLE
Allow users to hide the map they're in

### DIFF
--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -462,7 +462,21 @@ namespace Celeste.Mod.CelesteNet.Client {
             public bool HideOwnChannelName { get; set; } = false;
 
             [SettingSubText("modoptions_celestenetclient_hideownlocationhint")]
-            public bool HideOwnLocation { get; set; } = true;
+            public bool HideOwnLocation {
+                get => _HideOwnLocation;
+                set
+                {
+                    if (_HideOwnLocation == value)
+                        return;
+
+                    _HideOwnLocation = value;
+
+                    if (CelesteNetClientModule.Instance.Context != null)
+                        CelesteNetClientModule.Instance.Context.Main.StateUpdated = true;
+                }
+            }
+
+            private bool _HideOwnLocation = false;
 
             [SettingSubText("modoptions_celestenetclient_plscrollmodehint")]
             public CelesteNetPlayerListComponent.ScrollModes PlayerListScrollMode { get; set; } = CelesteNetPlayerListComponent.ScrollModes.HoldTab;

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -461,6 +461,9 @@ namespace Celeste.Mod.CelesteNet.Client {
             [SettingSubText("modoptions_celestenetclient_hideownchannelhint")]
             public bool HideOwnChannelName { get; set; } = false;
 
+            [SettingSubText("modoptions_celestenetclient_hideownlocationhint")]
+            public bool HideOwnLocation { get; set; } = true;
+
             [SettingSubText("modoptions_celestenetclient_plscrollmodehint")]
             public CelesteNetPlayerListComponent.ScrollModes PlayerListScrollMode { get; set; } = CelesteNetPlayerListComponent.ScrollModes.HoldTab;
 

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -11,6 +11,7 @@ using MonoMod.RuntimeDetour;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -920,14 +921,20 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         public void SendState() {
             try {
-                Client?.SendAndHandle(new DataPlayerState {
+                DataPlayerState playerState = new DataPlayerState {
                     Player = Client.PlayerInfo,
                     SID = Session?.Area.GetSID() ?? MapEditorArea?.SID ?? "",
                     Mode = Session?.Area.Mode ?? MapEditorArea?.Mode ?? AreaMode.Normal,
                     Level = Session?.Level ?? (MapEditorArea != null ? LevelDebugMap : ""),
                     Idle = ForceIdle.Count != 0 || (Player?.Scene is Level level && (level.FrozenOrPaused || level.Overlay != null)),
                     Interactive = Settings.InGame.Interactions
-                });
+                };
+                if (Client.Settings.PlayerListUI.HideOwnLocation) {
+                    playerState.SID = "";
+                    playerState.Mode = AreaMode.Normal;
+                    playerState.Level = "";
+                }
+                Client?.SendAndHandle(playerState);
             } catch (Exception e) {
                 Logger.Log(LogLevel.INF, "client-main", $"Error in SendState:\n{e}");
                 Context.DisposeSafe();

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -48,6 +48,8 @@
 	MODOPTIONS_CELESTENETCLIENT_RESETGENERALHINT=	Resets the options above to defaults, excluding Name/Key
 	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNEL=			Hide your channel name
 	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNELHINT=		Intended for streamers.{n}Prevents leaking your channel name when receiving a message or opening the player list.
+	MODOPTIONS_CELESTENETCLIENT_HIDEOWNLOCATION=		Hide your location
+	MODOPTIONS_CELESTENETCLIENT_HIDEOWNLOCATIONHINT=		Hides the map you're playing.{n}Useful when mapping in secret.
 	MODOPTIONS_CELESTENETCLIENT_SETTINGS=			Settings
 
 	MODOPTIONS_CELESTENETCLIENT_EXTRASERVERS_SLIDER= Switch Servers

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -48,7 +48,7 @@
 	MODOPTIONS_CELESTENETCLIENT_RESETGENERALHINT=	Resets the options above to defaults, excluding Name/Key
 	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNEL=			Hide your channel name
 	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNELHINT=		Intended for streamers.{n}Prevents leaking your channel name when receiving a message or opening the player list.
-	MODOPTIONS_CELESTENETCLIENT_HIDEOWNLOCATION=		Hide your location
+	MODOPTIONS_CELESTENETCLIENT_HIDEOWNLOCATION=		Hide Your location
 	MODOPTIONS_CELESTENETCLIENT_HIDEOWNLOCATIONHINT=		Hides the map you're playing.{n}Useful when mapping in secret.
 	MODOPTIONS_CELESTENETCLIENT_SETTINGS=			Settings
 


### PR DESCRIPTION
This feature will allow people to hide the map they're in. Useful for mapping in secret without having to worry about leaking map names *(or for people who hate socializing)*.