### PR TITLE
Use the 'global_name' from Discord API's JSON

### DIFF
--- a/CelesteNet.Server.FrontendModule/Content/frontend/main/index.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/main/index.js
@@ -114,7 +114,7 @@ function renderUser() {
 				<span class="button-icon"></span>
 				<span class="button-text">
 					<span class="button-icon discord-avatar" style=${`background-image: url(/api/avatar?uid=${info.UID})`}></span>
-					${info.Name}#${info.Discrim}
+					${info.Discrim == "" || info.Discrim == "0" ? `${info.Name}` : `${info.Name}#${info.Discrim}`}
 				</span>
 			</a>
 		</p>`);

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -68,7 +68,9 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                         f.SetSessionAuthCookie(c, sessionkey);
                         f.RespondJSON(c, new {
                             Key = sessionkey,
-                            Info = $"Welcome, {info.Name}#{info.Discrim}"
+                            Info = string.IsNullOrEmpty(info.Discrim) || info.Discrim == "0"
+                            ? $"Welcome, {info.Name} ({uid})"
+                            : $"Welcome, {info.Name}#{info.Discrim}"
                         });
                         return;
                     } else {

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
@@ -113,7 +113,15 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
             string key = f.Server.UserData.Create(uid, false);
             BasicUserInfo info = f.Server.UserData.Load<BasicUserInfo>(uid);
-            info.Name = userData.username.ToString();
+
+            if (!string.IsNullOrEmpty(userData.global_name)) {
+                info.Name = userData.global_name.ToString();
+            } else {
+                info.Name = userData.username.ToString();
+            }
+            if (info.Name.Length > 32) {
+                info.Name = info.Name.Substring(0, 32);
+            }
             info.Discrim = userData.discriminator.ToString();
             f.Server.UserData.Save(uid, info);
 


### PR DESCRIPTION
It contains a user's new global display name when it exists, use it instead of 'username'.

On old accounts "username" was basically the global display name, and also your account name in combination with the discriminator.
On accounts transitioned to unique usernames, the "username" field is very restrictive now and we're better of grabbing the global Display Name whenever possible anyways.

On unique username accounts, the discriminator '0' shows up which will be hidden in the frontend.

![image](https://github.com/0x0ade/CelesteNet/assets/1682215/4100c433-f0e6-4886-aa08-6f85fef0c368)
_(this screenshot is from old source code, I made this PRs changes afterwards)_
