### PR TITLE
Hide private /cc messages

### DIFF
--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -385,7 +385,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             lock (buffer) {
                 for (int i = Math.Max(-buffer.Moved, -count); i < 0; i++) {
                     DataChat? msg = buffer[i];
-                    if (msg != null && ((msg.Targets?.Length ?? 0) == 0 || auth))
+                    if (msg != null && ((msg.Targets == null) || auth))
                         log.Add(detailed ? msg.ToDetailedFrontendChat() : msg.ToFrontendChat());
                 }
             }


### PR DESCRIPTION
Sending a /cc message in an empty channel makes it appear in the /chatlog endpoint, even though it shouldn't.
This is already fixed locally in the server.