### PR TITLE
Return WebSocket command success 

### DIFF
--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDBan.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDBan.cs
@@ -20,7 +20,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             string? reason = (string?) input?.Reason;
             if (uids == null || uids.Length == 0 ||
                 (reason = reason?.Trim() ?? "").IsNullOrEmpty())
-                return null;
+                return false;
 
             BanInfo ban = new() {
                 UID = uids[0],
@@ -52,7 +52,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 Frontend.Server.UserData.Save(uid, ban);
             Frontend.BroadcastCMD(true, "update", Frontend.Settings.APIPrefix + "/userinfos");
 
-            return null;
+            return true;
         }
     }
 }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
@@ -19,8 +19,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             ChatModule chat = Frontend.Server.Get<ChatModule>();
 
             Channels channels = Frontend.Server.Channels;
-            lock (channels.All)
-            {
+            lock (channels.All) {
                 if (!channels.ByID.TryGetValue(input, out Channel? c))
                     return false;
 

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
@@ -14,18 +14,22 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         public override bool MustAuth => true;
         public override object? Run(uint input) {
             if (input == Channels.IdDefault)
-                return null;
+                return false;
 
             ChatModule chat = Frontend.Server.Get<ChatModule>();
 
             Channels channels = Frontend.Server.Channels;
             lock (channels.All)
-                if (channels.ByID.TryGetValue(input, out Channel? c))
-                    foreach (CelesteNetPlayerSession player in c.Players.ToArray()) {
-                        channels.Move(player, Channels.NameDefault);
-                        chat.SendTo(player, $"{c.Name} dissolved by server admin.", color: chat.Settings.ColorCommandReply);
-                    }
-            return null;
+            {
+                if (!channels.ByID.TryGetValue(input, out Channel? c))
+                    return false;
+
+                foreach (CelesteNetPlayerSession player in c.Players.ToArray()) {
+                    channels.Move(player, Channels.NameDefault);
+                    chat.SendTo(player, $"{c.Name} dissolved by server admin.", color: chat.Settings.ColorCommandReply);
+                }
+                return true;
+            }
         }
     }
 }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
@@ -13,16 +13,17 @@ using System.Threading.Tasks;
 namespace Celeste.Mod.CelesteNet.Server.Control {
     public class WSCMDKick : WSCMD<uint> {
         public override bool MustAuth => true;
-        public override object? Run(uint input) {
-            if (Frontend.Server.PlayersByID.TryGetValue(input, out CelesteNetPlayerSession? player)) {
-                ChatModule chat = Frontend.Server.Get<ChatModule>();
-                new DynamicData(player).Set("leaveReason", chat.Settings.MessageKick);
-                player.Dispose();
-                player.Con.Send(new DataDisconnectReason { Text = "Kicked" });
-                player.Con.Send(new DataInternalDisconnect());
-                return true;
-            }
-            return null;
+        public override object? Run(uint input)
+        {
+            if (!Frontend.Server.PlayersByID.TryGetValue(input, out CelesteNetPlayerSession? player))
+                return false;
+
+            ChatModule chat = Frontend.Server.Get<ChatModule>();
+            new DynamicData(player).Set("leaveReason", chat.Settings.MessageKick);
+            player.Dispose();
+            player.Con.Send(new DataDisconnectReason { Text = "Kicked" });
+            player.Con.Send(new DataInternalDisconnect());
+            return true;
         }
     }
 }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
@@ -13,8 +13,7 @@ using System.Threading.Tasks;
 namespace Celeste.Mod.CelesteNet.Server.Control {
     public class WSCMDKick : WSCMD<uint> {
         public override bool MustAuth => true;
-        public override object? Run(uint input)
-        {
+        public override object? Run(uint input) {
             if (!Frontend.Server.PlayersByID.TryGetValue(input, out CelesteNetPlayerSession? player))
                 return false;
 

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDMove.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDMove.cs
@@ -15,24 +15,16 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         public override bool MustAuth => true;
         public override object? Run(dynamic? input) {
             if (input == null)
-                return null;
+                return false;
 
             uint id = (uint?) input.ID ?? uint.MaxValue;
             string to = (string?) input.To ?? (string?) input.Channel ?? Channels.NameDefault;
 
-            Channels channels = Frontend.Server.Channels;
+            if (!Frontend.Server.PlayersByID.TryGetValue(id, out CelesteNetPlayerSession? player))
+                return false;
 
-            lock (channels.All) {
-                foreach (Channel c in channels.All) {
-                    CelesteNetPlayerSession? p = c.Players.FirstOrDefault(p => p.SessionID == id);
-                    if (p != null) {
-                        channels.Move(p, to);
-                        return null;
-                    }
-                }
-            }
-
-            return null;
+            Frontend.Server.Channels.Move(player, to);
+            return true;
         }
     }
 }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDStatus.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDStatus.cs
@@ -14,13 +14,13 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         public override bool MustAuth => true;
         public override object? Run(object? input) {
             if (input == null)
-                return null;
+                return false;
 
             if (input is string inputText) {
                 Frontend.Server.BroadcastAsync(new DataServerStatus {
                     Text = inputText
                 });
-                return null;
+                return true;
             }
 
             dynamic data = input;
@@ -34,7 +34,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
             Frontend.Server.BroadcastAsync(status);
 
-            return null;
+            return true;
         }
     }
 }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
@@ -15,14 +15,14 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         public override object? Run(dynamic? data) {
             string? uid = data?.UID, tag = data?.Tag;
             if (uid.IsNullOrEmpty() || tag.IsNullOrEmpty())
-                return null;
+                return false;
             if (!Frontend.Server.UserData.TryLoad(uid, out BasicUserInfo info))
-                return null;
+                return false;
             info.Tags.Add(tag);
             Frontend.Server.UserData.Save(uid, info);
             if (tag == BasicUserInfo.TAG_AUTH || tag == BasicUserInfo.TAG_AUTH_EXEC)
                 Frontend.Server.UserData.Create(uid, true);
-            return null;
+            return true;
         }
     }
 
@@ -32,12 +32,12 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         public override object? Run(dynamic? data) {
             string? uid = data?.UID, tag = data?.Tag;
             if (uid.IsNullOrEmpty() || tag.IsNullOrEmpty())
-                return null;
+                return false;
             if (!Frontend.Server.UserData.TryLoad(uid, out BasicUserInfo info))
-                return null;
+                return false;
             info.Tags.Remove(tag);
             Frontend.Server.UserData.Save(uid, info);
-            return null;
+            return true;
         }
     }
 }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDUnban.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDUnban.cs
@@ -15,12 +15,12 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         public override bool MustAuth => true;
         public override object? Run(string uid) {
             if ((uid = uid?.Trim() ?? "").IsNullOrEmpty())
-                return null;
+                return false;
 
             Frontend.Server.UserData.Delete<BanInfo>(uid);
             Frontend.BroadcastCMD(true, "update", Frontend.Settings.APIPrefix + "/userinfos");
 
-            return null;
+            return true;
         }
     }
 }


### PR DESCRIPTION
A bunch of WebSocket commands return `null`, which is sorta inconvenient i.e. when sending a ban or kick command. This PR will make a bunch of WSCMDs return whether they succeeded or not.

Also includes a bunch of simplifications for commands like `kick`, `kickwarn`, `move`, and `dissolve`, which shouldn't change anything.