### PR TITLE
Limit HairCount in graphics data

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -964,7 +964,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 animI++;
             }
 
-            int hairCount = player.Sprite.HairCount;
+            int hairCount = Calc.Clamp(player.Sprite.HairCount, 0, 30);
             Vector2[] hairScales = new Vector2[hairCount];
             for (int i = 0; i < hairCount; i++)
                 hairScales[i] = player.Hair.GetHairScale(i) * new Vector2(((i == 0) ? (int) player.Hair.Facing : 1) / Math.Abs(player.Sprite.Scale.X), 1);

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -258,6 +258,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             if (Client?.Data == null)
                 return;
 
+            if (frame.HairColors.Length > Ghost.MaxHairLength)
+                Array.Resize(ref frame.HairColors, Ghost.MaxHairLength);
+
             LastFrames[frame.Player.ID] = frame;
 
             Session session = Session;
@@ -964,7 +967,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 animI++;
             }
 
-            int hairCount = Calc.Clamp(player.Sprite.HairCount, 0, 30);
+            int hairCount = Calc.Clamp(player.Sprite.HairCount, 0, Ghost.MaxHairLength);
             Vector2[] hairScales = new Vector2[hairCount];
             for (int i = 0; i < hairCount; i++)
                 hairScales[i] = player.Hair.GetHairScale(i) * new Vector2(((i == 0) ? (int) player.Hair.Facing : 1) / Math.Abs(player.Sprite.Scale.X), 1);
@@ -1061,6 +1064,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 animID = -1;
 
             try {
+                int hairCount = Calc.Clamp(player.Sprite.HairCount, 0, Ghost.MaxHairLength);
+
                 Client?.Send(new DataPlayerFrame {
                     Player = Client.PlayerInfo,
 
@@ -1073,7 +1078,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     CurrentAnimationID = animID,
                     CurrentAnimationFrame = player.Sprite.CurrentAnimationFrame,
 
-                    HairColors = Enumerable.Range(0, player.Sprite.HairCount).Select(i => player.Hair.GetHairColor(i)).ToArray(),
+                    HairColors = Enumerable.Range(0, hairCount).Select(i => player.Hair.GetHairColor(i)).ToArray(),
                     HairTexture0 = player.Hair.GetHairTexture(0).AtlasPath,
                     HairSimulateMotion = player.Hair.SimulateMotion,
 

--- a/CelesteNet.Client/Entities/Ghost.cs
+++ b/CelesteNet.Client/Entities/Ghost.cs
@@ -50,6 +50,8 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         protected List<Action<Ghost>> UpdateQueue = new();
         protected bool IsUpdating;
 
+        public const int MaxHairLength = 30;
+
         public Ghost(CelesteNetClientContext context, DataPlayerInfo playerInfo, PlayerSpriteMode spriteMode)
             : base(Vector2.Zero) {
             Context = context;
@@ -290,8 +292,8 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
                 graphics.HairCount = 1;
                 graphics.HairScales = new[] { Vector2.One };
                 graphics.HairTextures = new[] { "characters/player/hair00" };
-            } else if (graphics.HairCount > 30) {
-                graphics.HairCount = 30;
+            } else if (graphics.HairCount > MaxHairLength) {
+                graphics.HairCount = MaxHairLength;
             }
 
             PlayerGraphics = graphics;

--- a/CelesteNet.Client/Entities/Ghost.cs
+++ b/CelesteNet.Client/Entities/Ghost.cs
@@ -1,11 +1,11 @@
-﻿using Celeste.Mod.CelesteNet.Client.Components;
-using Celeste.Mod.CelesteNet.DataTypes;
-using Microsoft.Xna.Framework;
-using Monocle;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Celeste.Mod.CelesteNet.Client.Components;
+using Celeste.Mod.CelesteNet.DataTypes;
+using Microsoft.Xna.Framework;
+using Monocle;
 
 namespace Celeste.Mod.CelesteNet.Client.Entities {
     [Tracked]
@@ -290,6 +290,8 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
                 graphics.HairCount = 1;
                 graphics.HairScales = new[] { Vector2.One };
                 graphics.HairTextures = new[] { "characters/player/hair00" };
+            } else if (graphics.HairCount > 30) {
+                graphics.HairCount = 30;
             }
 
             PlayerGraphics = graphics;
@@ -302,6 +304,8 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
             Hair.StepInFacingPerSegment = graphics.HairStepInFacingPerSegment;
             Hair.StepApproach = graphics.HairStepApproach;
             Hair.StepYSinePerSegment = graphics.HairStepYSinePerSegment;
+            if (graphics.HairCount > Hair.Nodes.Count)
+                Hair.Nodes.Capacity = graphics.HairCount;
             while (Hair.Nodes.Count < graphics.HairCount)
                 Hair.Nodes.Add(Hair.Nodes.LastOrDefault());
             while (Hair.Nodes.Count > graphics.HairCount)

--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -483,7 +483,7 @@ namespace Celeste.Mod.CelesteNet.Server {
         public bool Filter(CelesteNetConnection con, DataPlayerGraphics graphics) {
             if (graphics.HairCount > Server.Settings.MaxHairLength)
                 graphics.HairCount = Server.Settings.MaxHairLength;
-            // FIXME: Should there be some array resizing here?
+            // don't really need to resize arrays if they're bigger; it'll only send up to graphics.HairCount
             return true;
         }
 

--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -1,11 +1,11 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Monocle;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Celeste.Mod.CelesteNet.DataTypes;
+using Monocle;
 
 namespace Celeste.Mod.CelesteNet.Server {
     public class CelesteNetPlayerSession : IDisposable {
@@ -483,6 +483,7 @@ namespace Celeste.Mod.CelesteNet.Server {
         public bool Filter(CelesteNetConnection con, DataPlayerGraphics graphics) {
             if (graphics.HairCount > Server.Settings.MaxHairLength)
                 graphics.HairCount = Server.Settings.MaxHairLength;
+            // FIXME: Should there be some array resizing here?
             return true;
         }
 


### PR DESCRIPTION
Limit the HairCount and subsequently the resizing of arrays/Lists when DataPlayerGraphics sent and received