### PR TITLE
Build client with net7.0 as Core mod

### DIFF
--- a/CelesteNet.Client/CelesteNet.Client.csproj
+++ b/CelesteNet.Client/CelesteNet.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>9</LangVersion> <!-- FIXME: Figure out why dotnet needs this! -->
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Client</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Client</RootNamespace>
     <Nullable>disable</Nullable>

--- a/CelesteNet.Client/CelesteNet.Client.csproj
+++ b/CelesteNet.Client/CelesteNet.Client.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>9</LangVersion> <!-- FIXME: Figure out why dotnet needs this! -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>11</LangVersion>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Client</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Client</RootNamespace>
     <Nullable>disable</Nullable>

--- a/CelesteNet.Client/CelesteNetClientRC.cs
+++ b/CelesteNet.Client/CelesteNetClientRC.cs
@@ -42,7 +42,7 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public static void Shutdown() {
             Listener?.Abort();
-            ListenerThread?.Abort();
+            //ListenerThread?.Abort();
             Listener = null;
             ListenerThread = null;
         }

--- a/CelesteNet.Server.ChatModule/CelesteNet.Server.ChatModule.csproj
+++ b/CelesteNet.Server.ChatModule/CelesteNet.Server.ChatModule.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>9</LangVersion> <!-- FIXME: Figure out why dotnet needs this! -->
-    <TargetFrameworks>net452;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Server.ChatModule</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Server.Chat</RootNamespace>
   </PropertyGroup>

--- a/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
+++ b/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>9</LangVersion> <!-- FIXME: Figure out why dotnet needs this! -->
-    <TargetFrameworks>net452;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Server.FrontendModule</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Server.Control</RootNamespace>
   </PropertyGroup>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Server</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Server</RootNamespace>
     <OutputType>Exe</OutputType>

--- a/CelesteNet.Shared/CelesteNet.Shared.csproj
+++ b/CelesteNet.Shared/CelesteNet.Shared.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>9</LangVersion> <!-- FIXME: Figure out why dotnet needs this! -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>9</LangVersion>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Shared</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet</RootNamespace>
   </PropertyGroup>

--- a/CelesteNet.Shared/CelesteNet.Shared.csproj
+++ b/CelesteNet.Shared/CelesteNet.Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>9</LangVersion> <!-- FIXME: Figure out why dotnet needs this! -->
-    <TargetFrameworks>net452;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Shared</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet</RootNamespace>
   </PropertyGroup>

--- a/PublishClient.ps1
+++ b/PublishClient.ps1
@@ -3,7 +3,7 @@ Remove-Item -Recurse -Path PubClient
 Remove-Item -Path CelesteNet.Client.zip
 New-Item -ItemType directory -Path PubClient
 Copy-Item -Path everest.pubclient.yaml -Destination PubClient/everest.yaml
-Copy-Item -Recurse -Path CelesteNet.Client/bin/Release/net452/* -Destination PubClient
+Copy-Item -Recurse -Path CelesteNet.Client/bin/Release/net7.0/CelesteNet* -Destination PubClient
 Copy-Item -Recurse -Path Dialog -Destination PubClient
 Copy-Item -Recurse -Path Graphics -Destination PubClient
 Compress-Archive -Path PubClient/* -DestinationPath CelesteNet.Client.zip

--- a/PublishClient.sh
+++ b/PublishClient.sh
@@ -3,7 +3,8 @@ dotnet build CelesteNet.Client -c Release
 rm -rf PubClient CelesteNet.Client.zip
 mkdir PubClient
 cp everest.pubclient.yaml PubClient/everest.yaml
-cp -r CelesteNet.Client/bin/Release/net452/* PubClient
+cp -r CelesteNet.Client/bin/Release/net7.0/CelesteNet.* PubClient
+[ -f PubClient/CelesteNet.Client.deps.json ] && rm PubClient/CelesteNet.Client.deps.json
 cp -r Dialog PubClient
 cp -r Graphics PubClient
 cd PubClient; zip -r ../CelesteNet.Client.zip *

--- a/everest.pubclient.yaml
+++ b/everest.pubclient.yaml
@@ -2,5 +2,5 @@
   Version: 2.2.2
   DLL: CelesteNet.Client.dll
   Dependencies:
-    - Name: Everest
-      Version: 1.3761.0
+    - Name: EverestCore
+      Version: 1.4465.0

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: CelesteNet.Client
   Version: 2.2.2
-  DLL: CelesteNet.Client/bin/Debug/net452/CelesteNet.Client.dll
+  DLL: CelesteNet.Client/bin/Debug/net6.0/CelesteNet.Client.dll
   Dependencies:
-    - Name: Everest
-      Version: 1.3761.0
+    - Name: EverestCore
+      Version: 1.4465.0

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: CelesteNet.Client
   Version: 2.2.2
-  DLL: CelesteNet.Client/bin/Debug/net6.0/CelesteNet.Client.dll
+  DLL: CelesteNet.Client/bin/Debug/net7.0/CelesteNet.Client.dll
   Dependencies:
     - Name: EverestCore
       Version: 1.4465.0


### PR DESCRIPTION
Client seems to work fine when built against ~~Net 6.0~~ .Net 7.0 as an Everest Core mod

 - set dependency in everest.yaml as `EverestCore` against version 4465
 - ~~with Client and shared only targeting net6.0, now all projects target net6.0, since server did already... should test targeting net7.0 I guess~~
 - Client seems fine/potentially better off targeting net7.0 same as Everest Core, but we can't build Server for net7.0 yet because of the WebsocketSharp library jank... so now Shared targets net6.0 and net7.0 just in case
 - Bumped C# Language Version for Client from 9 to 11, I don't think much has changed and nothing's breaking(?)
 - the `Thread.Abort()` needs to be taken out of CelesteNetClientRC.cs because it now [throws Exception always, because obsolete](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.abort?view=net-6.0)...