### PR TITLE
Cleanup usings (finally)

### DIFF
--- a/CelesteNet.Client/CelesteNetClientContext.cs
+++ b/CelesteNet.Client/CelesteNetClientContext.cs
@@ -1,17 +1,13 @@
 ﻿using Celeste.Mod.CelesteNet.Client.Components;
 using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Monocle;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using MDraw = Monocle.Draw;
 
-namespace Celeste.Mod.CelesteNet.Client {
+namespace Celeste.Mod.CelesteNet.Client
+{
     public class CelesteNetClientContext : DrawableGameComponent {
 
         public CelesteNetClient Client;

--- a/CelesteNet.Client/CelesteNetClientFont.cs
+++ b/CelesteNet.Client/CelesteNetClientFont.cs
@@ -1,24 +1,8 @@
-﻿using MC = Mono.Cecil;
-using CIL = Mono.Cecil.Cil;
-
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
+﻿using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Client {
+namespace Celeste.Mod.CelesteNet.Client
+{
     // Copy of ActiveFont that always uses the English font.
     public static class CelesteNetClientFont {
 

--- a/CelesteNet.Client/CelesteNetClientFontMono.cs
+++ b/CelesteNet.Client/CelesteNetClientFontMono.cs
@@ -1,24 +1,8 @@
-﻿using MC = Mono.Cecil;
-using CIL = Mono.Cecil.Cil;
-
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
+﻿using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Client {
+namespace Celeste.Mod.CelesteNet.Client
+{
     // Copy of ActiveFont that always uses a font with monospace Latin characters / Arabic numbers.
     public static class CelesteNetClientFontMono {
 

--- a/CelesteNet.Client/CelesteNetClientSpriteDB.cs
+++ b/CelesteNet.Client/CelesteNetClientSpriteDB.cs
@@ -1,24 +1,9 @@
-﻿using MC = Mono.Cecil;
-using CIL = Mono.Cecil.Cil;
-
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Monocle;
-using MonoMod.Utils;
-using System;
+﻿using Monocle;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Client {
+namespace Celeste.Mod.CelesteNet.Client
+{
     public static class CelesteNetClientSpriteDB {
 
         private static ConditionalWeakTable<Sprite, SpriteExt> SpriteExts = new();

--- a/CelesteNet.Client/CelesteNetClientTCPUDPConnection.cs
+++ b/CelesteNet.Client/CelesteNetClientTCPUDPConnection.cs
@@ -1,15 +1,14 @@
 using Celeste.Mod.CelesteNet.DataTypes;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 
-namespace Celeste.Mod.CelesteNet.Client {
+namespace Celeste.Mod.CelesteNet.Client
+{
     public class CelesteNetClientTCPUDPConnection : CelesteNetTCPUDPConnection {
 
         public const int UDPBufferSize = 65536;

--- a/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
@@ -1,19 +1,13 @@
-﻿using Celeste.Mod.CelesteNet.Client.Entities;
-using Celeste.Mod.CelesteNet.DataTypes;
+﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using Monocle;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MDraw = Monocle.Draw;
 
-namespace Celeste.Mod.CelesteNet.Client.Components {
+namespace Celeste.Mod.CelesteNet.Client.Components
+{
     public class CelesteNetEmojiComponent : CelesteNetGameComponent {
 
         public class NetEmojiContent : ModContent {

--- a/CelesteNet.Client/Components/CelesteNetEmoteComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmoteComponent.cs
@@ -1,17 +1,11 @@
 ﻿using Celeste.Mod.CelesteNet.Client.Entities;
 using Celeste.Mod.CelesteNet.DataTypes;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using Monocle;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MDraw = Monocle.Draw;
 
-namespace Celeste.Mod.CelesteNet.Client.Components {
+namespace Celeste.Mod.CelesteNet.Client.Components
+{
     public class CelesteNetEmoteComponent : CelesteNetGameComponent {
 
         public Player Player;

--- a/CelesteNet.Client/Components/CelesteNetKillGhostNetComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetKillGhostNetComponent.cs
@@ -1,19 +1,8 @@
-﻿using Celeste.Mod.CelesteNet.Client.Entities;
-using Celeste.Mod.CelesteNet.DataTypes;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using Microsoft.Xna.Framework;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using MDraw = Monocle.Draw;
 
-namespace Celeste.Mod.CelesteNet.Client.Components {
+namespace Celeste.Mod.CelesteNet.Client.Components
+{
     public class CelesteNetKillGhostNetComponent : CelesteNetGameComponent {
 
         public object GhostNetModule;

--- a/CelesteNet.Client/Components/CelesteNetModShareComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetModShareComponent.cs
@@ -1,20 +1,12 @@
-﻿using Celeste.Mod.CelesteNet.Client.Entities;
-using Celeste.Mod.CelesteNet.DataTypes;
+﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.UI;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using Monocle;
-using MonoMod.Cil;
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MDraw = Monocle.Draw;
 
-namespace Celeste.Mod.CelesteNet.Client.Components {
+namespace Celeste.Mod.CelesteNet.Client.Components
+{
     public class CelesteNetModShareComponent : CelesteNetGameComponent {
 
         public List<EverestModuleMetadata> Requested = new();

--- a/CelesteNet.Client/Components/CelesteNetRenderHelperComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetRenderHelperComponent.cs
@@ -1,20 +1,14 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod.Cil;
-using MonoMod.RuntimeDetour;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using MDraw = Monocle.Draw;
 
-namespace Celeste.Mod.CelesteNet.Client.Components {
+namespace Celeste.Mod.CelesteNet.Client.Components
+{
     public unsafe class CelesteNetRenderHelperComponent : CelesteNetGameComponent {
 
         public int BlurScale => Settings.UIBlur switch {

--- a/CelesteNet.Client/Components/CelesteNetStatusComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetStatusComponent.cs
@@ -1,15 +1,9 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using MDraw = Monocle.Draw;
 
-namespace Celeste.Mod.CelesteNet.Client.Components {
+namespace Celeste.Mod.CelesteNet.Client.Components
+{
     public class CelesteNetStatusComponent : CelesteNetGameComponent {
 
         private bool show;

--- a/CelesteNet.Client/DebugCommands.cs
+++ b/CelesteNet.Client/DebugCommands.cs
@@ -1,24 +1,7 @@
-﻿using MC = Mono.Cecil;
-using CIL = Mono.Cecil.Cil;
+﻿using Monocle;
 
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Monocle;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Client {
+namespace Celeste.Mod.CelesteNet.Client
+{
     public static class DebugCommands {
 
         [Command("con", "connect to a celestenet server")]

--- a/CelesteNet.Client/Entities/GhostDeadBody.cs
+++ b/CelesteNet.Client/Entities/GhostDeadBody.cs
@@ -1,9 +1,9 @@
 using Microsoft.Xna.Framework;
 using Monocle;
-using System;
 using System.Collections;
 
-namespace Celeste.Mod.CelesteNet.Client.Entities {
+namespace Celeste.Mod.CelesteNet.Client.Entities
+{
     public class GhostDeadBody : Entity {
         private Color initialHairColor;
 

--- a/CelesteNet.Client/Entities/GhostEntity.cs
+++ b/CelesteNet.Client/Entities/GhostEntity.cs
@@ -1,12 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Client.Entities {
+namespace Celeste.Mod.CelesteNet.Client.Entities
+{
     public class GhostEntity : Entity {
 
         public Ghost Ghost;

--- a/CelesteNet.Client/Entities/GhostFollower.cs
+++ b/CelesteNet.Client/Entities/GhostFollower.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Monocle;
 
-namespace Celeste.Mod.CelesteNet.Client.Entities {
+namespace Celeste.Mod.CelesteNet.Client.Entities
+{
     public class GhostFollower : GhostEntity {
 
         public Follower Follower;

--- a/CelesteNet.Client/Entities/PauseUpdateOverlay.cs
+++ b/CelesteNet.Client/Entities/PauseUpdateOverlay.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Monocle;
 
-namespace Celeste.Mod.CelesteNet.Client.Entities {
+namespace Celeste.Mod.CelesteNet.Client.Entities
+{
     public class PauseUpdateOverlay : Overlay {
 
         public override void Update() {

--- a/CelesteNet.Server.ChatModule/SpamContext.cs
+++ b/CelesteNet.Server.ChatModule/SpamContext.cs
@@ -1,19 +1,11 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod.Utils;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Chat {
+namespace Celeste.Mod.CelesteNet.Server.Chat
+{
     public class SpamContext : IDisposable {
 
         public readonly ChatModule Chat;

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -9,16 +9,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
 using WebSocketSharp.Server;
-using Celeste.Mod.Helpers;
 using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat;
 using System.Timers;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class Frontend : CelesteNetServerModule<FrontendSettings> {
 
         public static readonly string COOKIE_SESSION = "celestenet-session";

--- a/CelesteNet.Server.FrontendModule/FrontendSettings.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendSettings.cs
@@ -1,14 +1,9 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
 using YamlDotNet.Serialization;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class FrontendSettings : CelesteNetServerModuleSettings {
 
         // Make sure to update your index.html as well!

--- a/CelesteNet.Server.FrontendModule/FrontendUtils.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendUtils.cs
@@ -1,17 +1,9 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public static class FrontendUtils {
 
         public static object ToFrontendChat(this DataChat msg)

--- a/CelesteNet.Server.FrontendModule/FrontendWebSocket.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendWebSocket.cs
@@ -1,21 +1,13 @@
-﻿using IL.Monocle;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Reflection;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Web;
 using WebSocketSharp;
 using WebSocketSharp.Server;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class FrontendWebSocket : WebSocketBehavior {
 
         // Each connection creates one instance of this.

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat;
 using Newtonsoft.Json;
@@ -18,10 +17,10 @@ using System.Runtime.Loader;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
-using Microsoft.CodeAnalysis.Text;
 #endif
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public static partial class RCEndpoints {
 
         [RCEndpoint(false, "/auth", null, null, "Authenticate", "Basic POST authentication endpoint.")]

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPMeta.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPMeta.cs
@@ -1,23 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CelesteNet.Server.Chat;
-using Newtonsoft.Json;
+﻿using System.Collections.Specialized;
 using WebSocketSharp.Net;
 using WebSocketSharp.Server;
 
 #if NETCORE
-using System.Runtime.Loader;
 #endif
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public static partial class RCEndpoints {
 
         [RCEndpoint(false, "/deauth", "", "", "Deauthenticate", "Deauthenticate and force-unset all set cookies.")]

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CelesteNet.Server.Chat;
 using Newtonsoft.Json;
 using WebSocketSharp.Net;
 using WebSocketSharp.Server;
@@ -18,10 +11,10 @@ using System.Drawing.Imaging;
 using System.Drawing.Drawing2D;
 
 #if NETCORE
-using System.Runtime.Loader;
 #endif
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public static partial class RCEndpoints {
 
         [RCEndpoint(false, "/discordauth", "", "", "Discord OAuth2", "User auth using Discord.")]

--- a/CelesteNet.Server.FrontendModule/RCEndpoint.cs
+++ b/CelesteNet.Server.FrontendModule/RCEndpoint.cs
@@ -1,16 +1,9 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Net;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using WebSocketSharp.Server;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class RCEndpoint {
         public bool Auth;
         public string Path = "";

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDAuth.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDAuth.cs
@@ -1,14 +1,5 @@
-﻿using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Control {
+﻿namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDAuth : WSCMD<string> {
         public override bool MustAuth => false;
         public override object? Run(string data) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDBan.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDBan.cs
@@ -1,17 +1,12 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
 using MonoMod.Utils;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDBan : WSCMD {
         public override bool MustAuth => true;
         public override object? Run(dynamic? input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChat.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChat.cs
@@ -1,15 +1,7 @@
 ﻿using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDChat : WSCMD<string> {
         public override bool MustAuth => true;
         public override object? Run(string input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatEdit.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatEdit.cs
@@ -1,17 +1,9 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
 using Monocle;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDChatEdit : WSCMD {
         public override bool MustAuth => true;
         public override object? Run(dynamic? input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatX.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDChatX.cs
@@ -1,19 +1,12 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat;
-using Microsoft.Xna.Framework;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
 using Monocle;
-using MonoMod.Utils;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDChatX : WSCMD {
         public override bool MustAuth => true;
         public override object? Run(dynamic? input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDCount.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDCount.cs
@@ -1,14 +1,5 @@
-﻿using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Control {
+﻿namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDCount : WSCMD {
         public override bool MustAuth => false;
         public int Counter;

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDDissolve.cs
@@ -1,15 +1,8 @@
 ﻿using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDDissolve : WSCMD<uint> {
         public override bool MustAuth => true;
         public override object? Run(uint input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDEcho.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDEcho.cs
@@ -1,14 +1,5 @@
-﻿using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Control {
+﻿namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDEcho : WSCMD {
         public override bool MustAuth => false;
         public override object? Run(object? data) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDHelp.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDHelp.cs
@@ -1,14 +1,7 @@
-﻿using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDHelp : WSCMD {
         public override bool MustAuth => false;
         public override object? Run(object? input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
@@ -1,16 +1,9 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
 using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDKick : WSCMD<uint> {
         public override bool MustAuth => true;
         public override object? Run(uint input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKickWarn.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKickWarn.cs
@@ -1,16 +1,10 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
 using MonoMod.Utils;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDKickWarn : WSCMD {
         public override bool MustAuth => true;
         public override object? Run(dynamic? input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDMove.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDMove.cs
@@ -1,16 +1,5 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Control {
+﻿namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDMove : WSCMD {
         public override bool MustAuth => true;
         public override object? Run(dynamic? input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDReauth.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDReauth.cs
@@ -1,15 +1,5 @@
-﻿using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Control {
+﻿namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDReauth : WSCMD<string> {
         public override bool MustAuth => false;
         public override object? Run(string data) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDStatus.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDStatus.cs
@@ -1,16 +1,8 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDStatus : WSCMD {
         public override bool MustAuth => true;
         public override object? Run(object? input) {

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
@@ -1,14 +1,5 @@
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDTagAdd : WSCMD {
         public override bool MustAuth => true;
         public override bool MustAuthExec => true;

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDUnban.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDUnban.cs
@@ -1,16 +1,5 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CelesteNet.Server.Chat;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using MonoMod.Utils;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Control {
+﻿namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCMDUnban : WSCMD<string> {
         public override bool MustAuth => true;
         public override object? Run(string uid) {

--- a/CelesteNet.Server.FrontendModule/WSCommands.cs
+++ b/CelesteNet.Server.FrontendModule/WSCommands.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using Celeste.Mod.Helpers;
 
-namespace Celeste.Mod.CelesteNet.Server.Control {
+namespace Celeste.Mod.CelesteNet.Server.Control
+{
     public class WSCommands {
         public readonly Dictionary<string, WSCMD> All = new Dictionary<string, WSCMD>();
 

--- a/CelesteNet.Server.SqliteModule/MessagePackHelper.cs
+++ b/CelesteNet.Server.SqliteModule/MessagePackHelper.cs
@@ -1,15 +1,12 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MessagePack;
 using MessagePack.Formatters;
 using MessagePack.Resolvers;
 
-namespace Celeste.Mod.CelesteNet.Server.Sqlite {
+namespace Celeste.Mod.CelesteNet.Server.Sqlite
+{
     public static class MessagePackHelper {
 
         public static readonly MessagePackSerializerOptions Options = ContractlessStandardResolver.Options

--- a/CelesteNet.Server.SqliteModule/SqliteModule.cs
+++ b/CelesteNet.Server.SqliteModule/SqliteModule.cs
@@ -1,19 +1,5 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Microsoft.Xna.Framework;
-using MonoMod.Utils;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Sqlite {
+﻿namespace Celeste.Mod.CelesteNet.Server.Sqlite
+{
     public class SqliteModule : CelesteNetServerModule<SqliteSettings> {
 
         public override void LoadSettings() {

--- a/CelesteNet.Server.SqliteModule/SqliteSettings.cs
+++ b/CelesteNet.Server.SqliteModule/SqliteSettings.cs
@@ -1,12 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.Server.Sqlite {
+﻿namespace Celeste.Mod.CelesteNet.Server.Sqlite
+{
     public class SqliteSettings : CelesteNetServerModuleSettings {
 
         public bool Enabled { get; set; } = true;

--- a/CelesteNet.Server.SqliteModule/SqliteUserData.cs
+++ b/CelesteNet.Server.SqliteModule/SqliteUserData.cs
@@ -1,19 +1,15 @@
 ﻿using MessagePack;
 using Microsoft.Data.Sqlite;
-using Microsoft.Xna.Framework;
-using Monocle;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Transactions;
 
-namespace Celeste.Mod.CelesteNet.Server.Sqlite {
+namespace Celeste.Mod.CelesteNet.Server.Sqlite
+{
     public sealed class SqliteUserData : UserData {
 
         public static readonly HashSet<char> Illegal = new("`´'\"^[]\\//");

--- a/CelesteNet.Server/CelesteNetServer.cs
+++ b/CelesteNet.Server/CelesteNetServer.cs
@@ -1,23 +1,19 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Cecil;
-using Mono.Options;
 using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Sockets;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public class CelesteNetServer : IDisposable {
 
         public readonly DateTime StartupTime;

--- a/CelesteNet.Server/CelesteNetServerModule.cs
+++ b/CelesteNet.Server/CelesteNetServerModule.cs
@@ -1,21 +1,10 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Options;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Sockets;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public abstract class CelesteNetServerModule : IDisposable {
 
 #pragma warning disable CS8618 // Set on init.

--- a/CelesteNet.Server/CelesteNetServerModuleWrapper.Core.cs
+++ b/CelesteNet.Server/CelesteNetServerModuleWrapper.Core.cs
@@ -1,20 +1,11 @@
 ﻿#if NETCORE
-using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Options;
 using System;
-using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public partial class CelesteNetServerModuleWrapper {
 
         private AssemblyLoadContext? ALC;

--- a/CelesteNet.Server/CelesteNetServerModuleWrapper.cs
+++ b/CelesteNet.Server/CelesteNetServerModuleWrapper.cs
@@ -1,20 +1,11 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Cecil;
-using Mono.Options;
+﻿using Mono.Cecil;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
 using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public partial class CelesteNetServerModuleWrapper {
 
         public readonly CelesteNetServer Server;

--- a/CelesteNet.Server/CelesteNetServerSettings.cs
+++ b/CelesteNet.Server/CelesteNetServerSettings.cs
@@ -1,16 +1,8 @@
-﻿using Microsoft.Xna.Framework;
-using Mono.Options;
-using Monocle;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Newtonsoft.Json;
 using YamlDotNet.Serialization;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public class CelesteNetServerSettings : CelesteNetServerModuleSettings {
 
         [YamlIgnore]

--- a/CelesteNet.Server/Channels.cs
+++ b/CelesteNet.Server/Channels.cs
@@ -1,16 +1,9 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Options;
-using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public class Channels : IDisposable {
 
         public const string NameDefault = "main";

--- a/CelesteNet.Server/ConPlus/TCPAcceptorRole.cs
+++ b/CelesteNet.Server/ConPlus/TCPAcceptorRole.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public partial class TCPAcceptorRole : MultipleSocketBinderRole {
 
         public const int MaxWorkerBacklog = 32;

--- a/CelesteNet.Server/ConPlus/TCPFallbackPoller.cs
+++ b/CelesteNet.Server/ConPlus/TCPFallbackPoller.cs
@@ -1,10 +1,10 @@
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Threading;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     /*
     This poller is slower, but it works on all platforms. Using the EPoll poller
     on Linux is recommended for optimal performance.

--- a/CelesteNet.Server/ConPlus/TCPReceiverRole.cs
+++ b/CelesteNet.Server/ConPlus/TCPReceiverRole.cs
@@ -1,10 +1,9 @@
-using Celeste.Mod.CelesteNet.Server;
 using System;
 using System.Collections.Generic;
-using System.Net.Sockets;
 using System.Threading;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public class TCPReceiverRole : NetPlusThreadRole {
 
         public interface IPoller : IDisposable {

--- a/CelesteNet.Server/ConPlus/TCPUDPSenderRole.cs
+++ b/CelesteNet.Server/ConPlus/TCPUDPSenderRole.cs
@@ -2,12 +2,12 @@ using Celeste.Mod.CelesteNet.DataTypes;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     /*
     The TCP/UDP sender role gets specified as the queue flusher for the TCP/UDP
     send queues. When a queue needs to be flushed, it get's added to a queue of

--- a/CelesteNet.Server/FileSystemUserData.cs
+++ b/CelesteNet.Server/FileSystemUserData.cs
@@ -1,17 +1,11 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Options;
-using MonoMod.Utils;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public class FileSystemUserData : UserData {
 
         public readonly object GlobalLock = new();

--- a/CelesteNet.Server/LogWriter.cs
+++ b/CelesteNet.Server/LogWriter.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
+﻿using System.IO;
 using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     // Based off of Everest's LogWriter.
     public class LogWriter : TextWriter {
 

--- a/CelesteNet.Server/NetPlus/ThreadRole.cs
+++ b/CelesteNet.Server/NetPlus/ThreadRole.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     /*
     A thread role represents something a thread could be doing, e.g. waiting for
     TCP connections, polling sockets, flushing send queues, or just ideling. The

--- a/CelesteNet.Server/Program.cs
+++ b/CelesteNet.Server/Program.cs
@@ -1,18 +1,14 @@
 ﻿#define INMODDIR
 
-using Celeste.Mod.CelesteNet.DataTypes;
 using Mono.Options;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public static class Program {
 
         public static CelesteNetServer? Server;

--- a/CelesteNet.Server/UserData.cs
+++ b/CelesteNet.Server/UserData.cs
@@ -1,17 +1,9 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Mono.Options;
-using MonoMod.Utils;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.Server {
+namespace Celeste.Mod.CelesteNet.Server
+{
     public abstract class UserData : IDisposable {
 
         public readonly CelesteNetServer Server;

--- a/CelesteNet.Shared/CelesteNetBinaryBlobPartWriter.cs
+++ b/CelesteNet.Shared/CelesteNetBinaryBlobPartWriter.cs
@@ -1,16 +1,9 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Microsoft.Xna.Framework;
-using Monocle;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public class CelesteNetBinaryBlobPartWriter : CelesteNetBinaryWriter {
 
         public readonly DataInternalBlob Blob;

--- a/CelesteNet.Shared/CelesteNetBinaryReader.cs
+++ b/CelesteNet.Shared/CelesteNetBinaryReader.cs
@@ -2,15 +2,10 @@
 using Microsoft.Xna.Framework;
 using Monocle;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public class CelesteNetBinaryReader : BinaryReader {
 
         public readonly DataContext Data;

--- a/CelesteNet.Shared/CelesteNetBinaryWriter.cs
+++ b/CelesteNet.Shared/CelesteNetBinaryWriter.cs
@@ -1,17 +1,11 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
 using Microsoft.Xna.Framework;
-using Monocle;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public class CelesteNetBinaryWriter : BinaryWriter {
 
         public readonly DataContext Data;

--- a/CelesteNet.Shared/CelesteNetUtils.EnglishFontChars.cs
+++ b/CelesteNet.Shared/CelesteNetUtils.EnglishFontChars.cs
@@ -1,19 +1,8 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public static partial class CelesteNetUtils {
 
         // Yes, this is better than trying to find the original font file and parsing it.

--- a/CelesteNet.Shared/CelesteNetUtils.cs
+++ b/CelesteNet.Shared/CelesteNetUtils.cs
@@ -1,19 +1,17 @@
 ﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public static partial class CelesteNetUtils {
 
         public const ushort Version = 2;

--- a/CelesteNet.Shared/ConnectionType.cs
+++ b/CelesteNet.Shared/ConnectionType.cs
@@ -1,19 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Monocle;
-
-namespace Celeste.Mod.CelesteNet {
+﻿namespace Celeste.Mod.CelesteNet
+{
     public enum ConnectionType {
         Auto,
         TCPUDP,

--- a/CelesteNet.Shared/ConnectionTypes/CelesteNetConnection.cs
+++ b/CelesteNet.Shared/ConnectionTypes/CelesteNetConnection.cs
@@ -1,19 +1,12 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Monocle;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public abstract class CelesteNetConnection : IDisposable {
 
         public readonly string Creator = "Unknown";

--- a/CelesteNet.Shared/ConnectionTypes/CelesteNetTCPUDPConnection.cs
+++ b/CelesteNet.Shared/ConnectionTypes/CelesteNetTCPUDPConnection.cs
@@ -1,11 +1,11 @@
 using Celeste.Mod.CelesteNet.DataTypes;
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public abstract class CelesteNetTCPUDPConnection : CelesteNetConnection {
 
         public class Settings {

--- a/CelesteNet.Shared/DataContext.cs
+++ b/CelesteNet.Shared/DataContext.cs
@@ -1,21 +1,16 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Monocle;
 using MonoMod.Utils;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public delegate void DataHandler(CelesteNetConnection con, DataType data);
     public delegate void DataHandler<T>(CelesteNetConnection con, T data) where T : DataType<T>;
     public delegate bool DataFilter(CelesteNetConnection con, DataType data);

--- a/CelesteNet.Shared/DataTypes/Data.cs
+++ b/CelesteNet.Shared/DataTypes/Data.cs
@@ -1,14 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public abstract class DataType {
 
         public virtual DataFlags DataFlags => DataFlags.None;

--- a/CelesteNet.Shared/DataTypes/DataAudioPlay.cs
+++ b/CelesteNet.Shared/DataTypes/DataAudioPlay.cs
@@ -1,16 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataAudioPlay : DataType<DataAudioPlay> {
 
         static DataAudioPlay() {

--- a/CelesteNet.Shared/DataTypes/DataChannelList.cs
+++ b/CelesteNet.Shared/DataTypes/DataChannelList.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataChannelList : DataType<DataChannelList> {
 
         static DataChannelList() {

--- a/CelesteNet.Shared/DataTypes/DataChannelMove.cs
+++ b/CelesteNet.Shared/DataTypes/DataChannelMove.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataChannelMove : DataType<DataChannelMove> {
 
         static DataChannelMove() {

--- a/CelesteNet.Shared/DataTypes/DataChat.cs
+++ b/CelesteNet.Shared/DataTypes/DataChat.cs
@@ -1,15 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataChat : DataType<DataChat> {
 
         static DataChat() {

--- a/CelesteNet.Shared/DataTypes/DataCommandList.cs
+++ b/CelesteNet.Shared/DataTypes/DataCommandList.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataCommandList : DataType<DataCommandList> {
 
         static DataCommandList() {

--- a/CelesteNet.Shared/DataTypes/DataConnectionInfo.cs
+++ b/CelesteNet.Shared/DataTypes/DataConnectionInfo.cs
@@ -1,16 +1,5 @@
-using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataConnectionInfo : DataType<DataConnectionInfo> {
 
         static DataConnectionInfo() {

--- a/CelesteNet.Shared/DataTypes/DataDashTrail.cs
+++ b/CelesteNet.Shared/DataTypes/DataDashTrail.cs
@@ -1,16 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataDashTrail : DataType<DataDashTrail> {
 
         static DataDashTrail() {

--- a/CelesteNet.Shared/DataTypes/DataDisconnectReason.cs
+++ b/CelesteNet.Shared/DataTypes/DataDisconnectReason.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataDisconnectReason : DataType<DataDisconnectReason> {
 
         static DataDisconnectReason() {

--- a/CelesteNet.Shared/DataTypes/DataEmote.cs
+++ b/CelesteNet.Shared/DataTypes/DataEmote.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataEmote : DataType<DataEmote> {
 
         static DataEmote() {

--- a/CelesteNet.Shared/DataTypes/DataInternalBlob.cs
+++ b/CelesteNet.Shared/DataTypes/DataInternalBlob.cs
@@ -1,17 +1,9 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataInternalBlob : DataType {
 
         public readonly DataType Data;

--- a/CelesteNet.Shared/DataTypes/DataInternalDisconnect.cs
+++ b/CelesteNet.Shared/DataTypes/DataInternalDisconnect.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataInternalDisconnect : DataType {
 
     }

--- a/CelesteNet.Shared/DataTypes/DataLowLevelKeepAlive.cs
+++ b/CelesteNet.Shared/DataTypes/DataLowLevelKeepAlive.cs
@@ -1,6 +1,5 @@
-using System;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataLowLevelKeepAlive : DataType<DataLowLevelKeepAlive> {
 
         static DataLowLevelKeepAlive() {

--- a/CelesteNet.Shared/DataTypes/DataLowLevelPingReply.cs
+++ b/CelesteNet.Shared/DataTypes/DataLowLevelPingReply.cs
@@ -1,16 +1,5 @@
-using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataLowLevelPingReply : DataType<DataLowLevelPingReply> {
 
         static DataLowLevelPingReply() {

--- a/CelesteNet.Shared/DataTypes/DataLowLevelPingRequest.cs
+++ b/CelesteNet.Shared/DataTypes/DataLowLevelPingRequest.cs
@@ -1,16 +1,5 @@
-using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataLowLevelPingRequest : DataType<DataLowLevelPingRequest> {
 
         static DataLowLevelPingRequest() {

--- a/CelesteNet.Shared/DataTypes/DataMapModInfo.cs
+++ b/CelesteNet.Shared/DataTypes/DataMapModInfo.cs
@@ -1,16 +1,7 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataMapModInfo : DataType<DataMapModInfo>, IDataRequestable<DataMapModInfoRequest> {
 
         static DataMapModInfo() {

--- a/CelesteNet.Shared/DataTypes/DataModRec.cs
+++ b/CelesteNet.Shared/DataTypes/DataModRec.cs
@@ -1,16 +1,7 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataModRec : DataType<DataModRec> {
 
         static DataModRec() {

--- a/CelesteNet.Shared/DataTypes/DataMoveTo.cs
+++ b/CelesteNet.Shared/DataTypes/DataMoveTo.cs
@@ -1,16 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataMoveTo : DataType<DataMoveTo> {
 
         static DataMoveTo() {

--- a/CelesteNet.Shared/DataTypes/DataNetEmoji.cs
+++ b/CelesteNet.Shared/DataTypes/DataNetEmoji.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataNetEmoji : DataType<DataNetEmoji> {
 
         static DataNetEmoji() {

--- a/CelesteNet.Shared/DataTypes/DataNetFilterList.cs
+++ b/CelesteNet.Shared/DataTypes/DataNetFilterList.cs
@@ -1,15 +1,8 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataNetFilterList : DataType<DataNetFilterList> {
 
         static DataNetFilterList() {

--- a/CelesteNet.Shared/DataTypes/DataPartAudioState.cs
+++ b/CelesteNet.Shared/DataTypes/DataPartAudioState.cs
@@ -1,17 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPartAudioState : DataType<DataPartAudioState> {
 
         public DataPartAudioTrackState? Music;

--- a/CelesteNet.Shared/DataTypes/DataPartAudioTrackState.cs
+++ b/CelesteNet.Shared/DataTypes/DataPartAudioTrackState.cs
@@ -1,17 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPartAudioTrackState : DataType<DataPartAudioTrackState> {
 
         public string Event = "";

--- a/CelesteNet.Shared/DataTypes/DataPartImage.cs
+++ b/CelesteNet.Shared/DataTypes/DataPartImage.cs
@@ -1,17 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPartImage : DataType<DataPartImage> {
 
         public string AtlasPath = "";

--- a/CelesteNet.Shared/DataTypes/DataPlayerFrame.cs
+++ b/CelesteNet.Shared/DataTypes/DataPlayerFrame.cs
@@ -1,16 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPlayerFrame : DataType<DataPlayerFrame> {
 
         static DataPlayerFrame() {

--- a/CelesteNet.Shared/DataTypes/DataPlayerGrabPlayer.cs
+++ b/CelesteNet.Shared/DataTypes/DataPlayerGrabPlayer.cs
@@ -1,16 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPlayerGrabPlayer : DataType<DataPlayerGrabPlayer> {
 
         public const byte MaxGrabStrength = 1 << 7 - 1;

--- a/CelesteNet.Shared/DataTypes/DataPlayerGraphics.cs
+++ b/CelesteNet.Shared/DataTypes/DataPlayerGraphics.cs
@@ -1,16 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPlayerGraphics : DataType<DataPlayerGraphics> {
 
         static DataPlayerGraphics() {

--- a/CelesteNet.Shared/DataTypes/DataPlayerInfo.cs
+++ b/CelesteNet.Shared/DataTypes/DataPlayerInfo.cs
@@ -1,16 +1,7 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPlayerInfo : DataType<DataPlayerInfo> {
 
         static DataPlayerInfo() {

--- a/CelesteNet.Shared/DataTypes/DataPlayerState.cs
+++ b/CelesteNet.Shared/DataTypes/DataPlayerState.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataPlayerState : DataType<DataPlayerState> {
 
         static DataPlayerState() {

--- a/CelesteNet.Shared/DataTypes/DataServerStatus.cs
+++ b/CelesteNet.Shared/DataTypes/DataServerStatus.cs
@@ -1,16 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataServerStatus : DataType<DataServerStatus> {
 
         static DataServerStatus() {

--- a/CelesteNet.Shared/DataTypes/DataSession.cs
+++ b/CelesteNet.Shared/DataTypes/DataSession.cs
@@ -1,16 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataSession : DataType<DataSession>, IDataRequestable<DataSessionRequest> {
 
         static DataSession() {

--- a/CelesteNet.Shared/DataTypes/DataUnparsed.cs
+++ b/CelesteNet.Shared/DataTypes/DataUnparsed.cs
@@ -1,17 +1,5 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class DataUnparsed : DataType<DataUnparsed> {
 
         public override DataFlags DataFlags => InnerFlags & ~DataFlags.Small;

--- a/CelesteNet.Shared/DisposeActionStream.cs
+++ b/CelesteNet.Shared/DisposeActionStream.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     // Based off of Everest's DisposeActionStream.
     public sealed class DisposeActionStream : Stream {
 

--- a/CelesteNet.Shared/Dummy.cs
+++ b/CelesteNet.Shared/Dummy.cs
@@ -1,18 +1,7 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public static class Dummy<T> {
 
         public static readonly T[] EmptyArray = new T[0];

--- a/CelesteNet.Shared/ListSnapshot.cs
+++ b/CelesteNet.Shared/ListSnapshot.cs
@@ -1,17 +1,10 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public class ListSnapshot<T> : IList<T>, IDisposable {
 
         internal bool Disposed;

--- a/CelesteNet.Shared/Logger.cs
+++ b/CelesteNet.Shared/Logger.cs
@@ -1,15 +1,11 @@
-﻿using Celeste.Mod.Helpers;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     // Based off of Everest's Logger.
     public static class Logger {
 

--- a/CelesteNet.Shared/MetaTypes/Meta.cs
+++ b/CelesteNet.Shared/MetaTypes/Meta.cs
@@ -1,15 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using MonoMod.Utils;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public abstract class MetaType {
 
         public virtual string GetTypeID(DataContext ctx)

--- a/CelesteNet.Shared/MetaTypes/MetaBoundRef.cs
+++ b/CelesteNet.Shared/MetaTypes/MetaBoundRef.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class MetaBoundRef : MetaType<MetaBoundRef> {
 
         static MetaBoundRef() {

--- a/CelesteNet.Shared/MetaTypes/MetaOrderedUpdate.cs
+++ b/CelesteNet.Shared/MetaTypes/MetaOrderedUpdate.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class MetaOrderedUpdate : MetaType<MetaOrderedUpdate> {
 
         static MetaOrderedUpdate() {

--- a/CelesteNet.Shared/MetaTypes/MetaRef.cs
+++ b/CelesteNet.Shared/MetaTypes/MetaRef.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class MetaRef : MetaType<MetaRef> {
 
         static MetaRef() {

--- a/CelesteNet.Shared/MetaTypes/MetaRequest.cs
+++ b/CelesteNet.Shared/MetaTypes/MetaRequest.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class MetaRequest : MetaType<MetaRequest> {
 
         static MetaRequest() {

--- a/CelesteNet.Shared/MetaTypes/MetaRequestResponse.cs
+++ b/CelesteNet.Shared/MetaTypes/MetaRequestResponse.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Celeste.Mod.CelesteNet.DataTypes {
+﻿namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class MetaRequestResponse : MetaType<MetaRequestResponse> {
 
         static MetaRequestResponse() {

--- a/CelesteNet.Shared/MetaTypes/MetaUnparsed.cs
+++ b/CelesteNet.Shared/MetaTypes/MetaUnparsed.cs
@@ -1,14 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet.DataTypes {
+namespace Celeste.Mod.CelesteNet.DataTypes
+{
     public class MetaUnparsed : MetaType<MetaUnparsed> {
 
         public string InnerID = "";

--- a/CelesteNet.Shared/OptMap.cs
+++ b/CelesteNet.Shared/OptMap.cs
@@ -1,16 +1,9 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     /*
     Generalized StringMaps into OptMaps
     -Popax21

--- a/CelesteNet.Shared/RWLock.cs
+++ b/CelesteNet.Shared/RWLock.cs
@@ -1,19 +1,8 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.Helpers;
-using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
+﻿using System;
 using System.Threading;
-using System.Threading.Tasks;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public class RWLock : IDisposable {
 
         public readonly ReaderWriterLockSlim Inner = new(LockRecursionPolicy.SupportsRecursion);

--- a/CelesteNet.Shared/RingBuffer.cs
+++ b/CelesteNet.Shared/RingBuffer.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public class RingBuffer<T> {
 
         public readonly T[] Data;

--- a/CelesteNet.Shared/StringDedupeContext.cs
+++ b/CelesteNet.Shared/StringDedupeContext.cs
@@ -1,16 +1,8 @@
-﻿using Microsoft.Xna.Framework;
-using Monocle;
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
+﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     // Because String.Intern is too global for my liking. -jade
     public unsafe class StringDedupeContext {
 

--- a/CelesteNet.Shared/StringInjectExtension.cs
+++ b/CelesteNet.Shared/StringInjectExtension.cs
@@ -1,11 +1,11 @@
 ﻿// Taken from http://mo.notono.us/2008/07/c-stringinject-format-strings-by-key.html
-using System;
 using System.Text.RegularExpressions;
 using System.Collections;
 using System.Globalization;
 using System.ComponentModel;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     public static class StringInjectExtension {
         /// <summary>
         /// Extension method that replaces keys in a string with the values of matching object properties.

--- a/CelesteNet.Shared/YamlHelper.cs
+++ b/CelesteNet.Shared/YamlHelper.cs
@@ -1,16 +1,13 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.ObjectFactories;
 
-namespace Celeste.Mod.CelesteNet {
+namespace Celeste.Mod.CelesteNet
+{
     // Based off of Everest's YamlHelper.
     public static class YamlHelper {
 


### PR DESCRIPTION
Used Visual Studio's "Remove redundant usings" feature across the entire solution. As a side effect it put all the namespace braces on a new line, but oh well.

Got it to build successfully, so LGTM