### PR TITLE
Update NuGet packages

### DIFF
--- a/CelesteNet.Client/CelesteNetClientRC.cs
+++ b/CelesteNet.Client/CelesteNetClientRC.cs
@@ -1,5 +1,4 @@
-﻿using MonoMod.Utils;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -26,7 +25,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                 Listener.Prefixes.Add($"http://localhost:{CelesteNetUtils.ClientRCPort}/");
                 Listener.Start();
             } catch (Exception e) {
-                e.LogDetailed();
+                Logger.LogDetailedException(e);
                 try {
                     Listener?.Stop();
                 } catch { }

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -68,9 +68,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             base.Initialize();
 
             MainThreadHelper.Do(() => {
-                using (new DetourContext("CelesteNetMain") {
-                    Before = { "*" }
-                }) {
+                // modern monomod does detourcontexts differently
+                using (new DetourConfigContext(new DetourConfig(
+                    "CelesteNetMain",
+                    before: new[] { "*" }
+                )).Use()) {
                     On.Monocle.Scene.SetActualDepth += OnSetActualDepth;
                     On.Celeste.Level.LoadLevel += OnLoadLevel;
                     Everest.Events.Level.OnExit += OnExitLevel;

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -71,7 +71,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 // modern monomod does detourcontexts differently
                 using (new DetourConfigContext(new DetourConfig(
                     "CelesteNetMain",
-                    before: new[] { "*" }
+                    int.MinValue  // this simulates before: "*"
                 )).Use()) {
                     On.Monocle.Scene.SetActualDepth += OnSetActualDepth;
                     On.Celeste.Level.LoadLevel += OnLoadLevel;

--- a/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
+++ b/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <Reference Include="System.Net.Http" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <!-- PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" /-->
     <Reference Include="WebSocketSharp.CustomHeaders.CustomHttpServer" HintPath="..\lib\$(TargetFramework)\WebSocketSharp.CustomHeaders.CustomHttpServer.dll" />
   </ItemGroup>

--- a/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
+++ b/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
@@ -24,7 +24,7 @@
     <When Condition="$(TargetFramework.Contains('.'))">
       <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-        <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+        <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="3.11.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
       </ItemGroup>

--- a/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
+++ b/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
@@ -25,8 +25,9 @@
       <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
         <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="3.11.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
       </ItemGroup>
     </When>
 

--- a/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
+++ b/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Net.Http" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <!-- PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" /-->
     <Reference Include="WebSocketSharp.CustomHeaders.CustomHttpServer" HintPath="..\lib\$(TargetFramework)\WebSocketSharp.CustomHeaders.CustomHttpServer.dll" />

--- a/CelesteNet.Server.SqliteModule/CelesteNet.Server.SqliteModule.csproj
+++ b/CelesteNet.Server.SqliteModule/CelesteNet.Server.SqliteModule.csproj
@@ -11,8 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.9" />
-    <PackageReference Include="MessagePack" Version="2.3.75" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.3.75" />
+    <PackageReference Include="MessagePack" Version="2.5.140" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.5.140">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/CelesteNet.Server.SqliteModule/CelesteNet.Server.SqliteModule.csproj
+++ b/CelesteNet.Server.SqliteModule/CelesteNet.Server.SqliteModule.csproj
@@ -10,7 +10,7 @@
   <Import Project="..\CelesteNet.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.9" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" />
     <PackageReference Include="MessagePack" Version="2.5.140" />
     <PackageReference Include="MessagePackAnalyzer" Version="2.5.140">
       <PrivateAssets>all</PrivateAssets>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -37,8 +37,9 @@
       <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
         <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="3.11.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
       </ItemGroup>
     </When>
 

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -29,7 +29,7 @@
   <!-- dotnet is stupid. The modules depend on this, but those deps (and their deps' deps) aren't shipped. -->
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <Choose>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -36,7 +36,7 @@
     <When Condition="$(TargetFramework.Contains('.'))">
       <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-        <PackageReference Include="System.Drawing.Common" Version="8.0.2"/>
+        <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="3.11.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
       </ItemGroup>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -53,8 +53,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.9" Condition="$(TargetFramework.Contains('.'))" />
-    <PackageReference Include="MessagePack" Version="2.3.75" Condition="$(TargetFramework.Contains('.'))" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.3.75" Condition="$(TargetFramework.Contains('.'))" />
+    <PackageReference Include="MessagePack" Version="2.5.140" Condition="$(TargetFramework.Contains('.'))" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.5.140" Condition="$(TargetFramework.Contains('.'))">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -52,7 +52,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.9" Condition="$(TargetFramework.Contains('.'))" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" Condition="$(TargetFramework.Contains('.'))" />
     <PackageReference Include="MessagePack" Version="2.5.140" Condition="$(TargetFramework.Contains('.'))" />
     <PackageReference Include="MessagePackAnalyzer" Version="2.5.140" Condition="$(TargetFramework.Contains('.'))">
       <PrivateAssets>all</PrivateAssets>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -21,7 +21,7 @@
 
   <Target Name="ClearModulesFolder" AfterTargets="AfterBuild" Condition="false">
     <ItemGroup>
-      <FilesToDelete Include="bin\$(Configuration)\$(TargetFramework)\Modules\**\*"/>
+      <FilesToDelete Include="bin\$(Configuration)\$(TargetFramework)\Modules\**\*" />
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" />
   </Target>
@@ -36,7 +36,7 @@
     <When Condition="$(TargetFramework.Contains('.'))">
       <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-        <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+        <PackageReference Include="System.Drawing.Common" Version="8.0.2"/>
         <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="3.11.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
       </ItemGroup>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
   </ItemGroup>
 

--- a/CelesteNet.Server/CelesteNetServerModuleWrapper.cs
+++ b/CelesteNet.Server/CelesteNetServerModuleWrapper.cs
@@ -97,7 +97,6 @@ namespace Celeste.Mod.CelesteNet.Server
 
             Module = null;
 
-            Server.DetourModManager.Unload(Assembly);
             Server.Data.RemoveDataTypes(Assembly.GetTypes());
 
             UnloadAssembly();

--- a/CelesteNet.props
+++ b/CelesteNet.props
@@ -105,11 +105,11 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="MonoMod.RuntimeDetour" Version="21.07.22.03">
+    <PackageReference Include="MonoMod.RuntimeDetour" Version="25.0.2">
       <PrivateAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">all</PrivateAssets>
       <ExcludeAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="MonoMod.Utils" Version="21.07.22.03">
+    <PackageReference Include="MonoMod.Utils" Version="25.0.3">
       <PrivateAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">all</PrivateAssets>
       <ExcludeAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">runtime</ExcludeAssets>
     </PackageReference>

--- a/CelesteNet.props
+++ b/CelesteNet.props
@@ -113,7 +113,7 @@
       <PrivateAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">all</PrivateAssets>
       <ExcludeAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="YamlDotNet" Version="8.1.2">
+    <PackageReference Include="YamlDotNet" Version="15.1.2">
       <PrivateAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">all</PrivateAssets>
       <ExcludeAssets Condition="$(InCelesteModDir) And $(IsNetFramework)">runtime</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updated all NuGet packages to the most recent version if possible.
Builds fine but still needs testing in case I broke something - hence the draft.

Exclusions are:
- `Mono.Cecil` [0.11.5]
  - due to it causing some type parameter weirdness on Everest;
    jbevain/cecil#931
- `MonoMod.RuntimeDetour` [25.1.0]
- `MonoMod.Utils` [25.0.4]
  - due to them being dependent on `Mono.Cecil` [0.11.5]