### PR TITLE
Startup + disconnect = lock freeze between threads

### DIFF
--- a/CelesteNet.Client/CelesteNetClientContext.cs
+++ b/CelesteNet.Client/CelesteNetClientContext.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.CelesteNet.Client.Components;
+using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using System;
@@ -136,6 +137,20 @@ namespace Celeste.Mod.CelesteNet.Client
             base.Draw(gameTime);
 
             // This must happen at the very end, as XNA / FNA won't update their internal lists, causing "dead" components to update.
+
+            DataDisconnectReason reason = CelesteNetClientModule.Instance.lastDisconnectReason;
+
+            if (reason != null) {
+                Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientContext Draw: Disposing because Client's lastDisconnectReason != null");
+
+                if (!Status.IsVisible)
+                    Status.Set(reason.Text, 8f, spin: false, dcReason: false);
+
+                if (!IsDisposed)
+                    Dispose();
+                return;
+            }
+
 
             if (SafeDisposeTriggered) {
                 Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientContext Draw: Disposing because SafeDisposeTriggered");

--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -9,6 +9,7 @@ using MonoMod.Utils;
 using System.Collections;
 using Celeste.Mod.CelesteNet.Client.Components;
 using System.IO;
+using Celeste.Mod.CelesteNet.DataTypes;
 
 namespace Celeste.Mod.CelesteNet.Client {
     public class CelesteNetClientModule : EverestModule {
@@ -35,6 +36,8 @@ namespace Celeste.Mod.CelesteNet.Client {
         private Thread _StartThread;
         private CancellationTokenSource _StartTokenSource;
         public bool IsAlive => Context != null;
+
+        public DataDisconnectReason lastDisconnectReason;
 
         public VirtualRenderTarget UIRenderTarget;
 
@@ -292,6 +295,8 @@ namespace Celeste.Mod.CelesteNet.Client {
                 Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientModule Start: StartThread Join done");
             }
             _StartTokenSource?.Dispose();
+
+            lastDisconnectReason = null;
 
             lock (ClientLock) {
                 Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientModule Start: old ctx: {Context} {Context?.IsDisposed}");

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -148,7 +148,11 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         #region Handlers
 
         public void Handle(CelesteNetConnection con, DataDisconnectReason reason) {
-            CelesteNetClientModule.Settings.Connected = false;
+            CelesteNetClientModule.Instance.lastDisconnectReason = reason;
+            // attempting to disconnect from within TCP recv thread here could cause game freeze
+            // if StartThread was also trying to dispose client context at the same time.
+            // So this will be handled within Client Context instead, based on lastDisconnectReason being set.
+            //CelesteNetClientModule.Settings.Connected = false;
         }
 
         public void Handle(CelesteNetConnection con, DataPlayerInfo player) {

--- a/CelesteNet.Client/Components/CelesteNetStatusComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetStatusComponent.cs
@@ -23,6 +23,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components
         public string Text => show ? text : null;
         public float Time => show ? timeTextMax : timeText;
         public bool Spin => spin;
+        public bool IsVisible => show;
 
         public CelesteNetStatusComponent(CelesteNetClientContext context, Game game)
             : base(context, game) {
@@ -46,13 +47,19 @@ namespace Celeste.Mod.CelesteNet.Client.Components
         }
 
         public void Handle(CelesteNetConnection con, DataDisconnectReason reason) {
-            Set(reason.Text, 8f, false);
+            Set(reason.Text, 8f, spin: false, dcReason: false);
         }
 
-        public void Set(string text, float timeText = timeTextMax, bool spin = true) {
+        public void Set(string text, float timeText = timeTextMax, bool spin = true, bool dcReason = true) {
             if (string.IsNullOrEmpty(text)) {
                 show = false;
                 return;
+            }
+
+            DataDisconnectReason reason = CelesteNetClientModule.Instance.lastDisconnectReason;
+
+            if (dcReason && reason != null && !reason.Text.IsNullOrEmpty()) {
+                text += $" ({reason.Text})";
             }
 
             this.text = text;

--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -83,6 +83,11 @@ namespace Celeste.Mod.CelesteNet.Server {
         }
 
         public T? Get<T>(object ctx) where T : class {
+            if (!Alive) {
+                Logger.Log(LogLevel.INF, "playersession", $"Early return on attempt to 'Get<{typeof(T)}>' when session is already !Alive");
+                return null;
+            }
+
             using (StateLock.R()) {
                 if (!StateContexts.TryGetValue(ctx, out Dictionary<Type, object>? states))
                     return null;
@@ -99,6 +104,11 @@ namespace Celeste.Mod.CelesteNet.Server {
             if (state == null)
                 return Remove<T>(ctx);
 
+            if (!Alive) {
+                Logger.Log(LogLevel.INF, "playersession", $"Early return on attempt to 'Set<{typeof(T)}>' when session is already !Alive");
+                return state;
+            }
+
             using (StateLock.W()) {
                 if (!StateContexts.TryGetValue(ctx, out Dictionary<Type, object>? states))
                     StateContexts[ctx] = states = new();
@@ -109,6 +119,11 @@ namespace Celeste.Mod.CelesteNet.Server {
         }
 
         public T? Remove<T>(object ctx) where T : class {
+            if (!Alive) {
+                Logger.Log(LogLevel.INF, "playersession", $"Early return on attempt to 'Remove<{typeof(T)}>' when session is already !Alive");
+                return null;
+            }
+
             using (StateLock.W()) {
                 if (!StateContexts.TryGetValue(ctx, out Dictionary<Type, object>? states))
                     return null;


### PR DESCRIPTION
As it says in the commit messages;

---

Fix game freeze if StartThread and RecvThread both try to dispose Client Context (e.g. disconnect during handshake).

Both Threads would end up waiting on each other
 - StartThread waiting to dispose ClientContext disposing Client disposing ClientTCPUDPConnection, ends up waiting to `TCPRecvThread.Join()`
 - TCPRecvThread handling a DataDisconnectReason, would set Connected = False on the Settings, which also calls ClientModule.Stop() which attempts to _StartThread.Join()
 - Main thread of the game will freeze because CelesteNetClientContext itself will _also_ try to Dispose itself, but its DisposeLock is already held up within StartThread

---

Also, attempt at patching over the fact that 'Disconnected' can immediately 'override' the status shown by a kick or ban or any other disconnect with a reason. Now it'll remember the reason and show it in brackets.

Conveying important disconnect reasons (i.e. user moderation) really needs better handling tbh.

---

Also a somewhat unrelated fix in Server where an Exception would pop up in the logger from trying to access/lock something on a dead/disconnecting player session.