### PR TITLE
Fix handshake with a ReadLine that REALLY doesn't try to buffer

### DIFF
--- a/CelesteNet.Client/Handshake.cs
+++ b/CelesteNet.Client/Handshake.cs
@@ -5,18 +5,36 @@ using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
 namespace Celeste.Mod.CelesteNet.Client {
     public static class Handshake {
 
+        private static string ReadLine(this NetworkStream netStream) {
+            //Unbuffered "read line" implementation reading every byte one at a time
+            //Extremely slow and inefficient, but otherwise we may gobble up binary packet bytes by accident :catresort:
+            List<char> lineChars = new List<char>();
+            while (true) {
+                int b = netStream.ReadByte();
+                if (b < 0)
+                    throw new EndOfStreamException();
+                else if (b == '\n')
+                    break;
+                else
+                    lineChars.Add((char)b);
+            }
+            if (lineChars.Count > 0 && lineChars[^1] == '\r') lineChars.RemoveAt(lineChars.Count - 1);
+            return new string(CollectionsMarshal.AsSpan(lineChars));
+        }
+
         // TODO MonoKickstart is so stupid, it can't even handle string.Split(char)...
         public static Tuple<uint, IConnectionFeature[], T> DoTeapotHandshake<T>(Socket sock, IConnectionFeature[] features, string nameKey, CelesteNetClientOptions options) where T : new() {
             // Find connection features
             // We don't buffer, as we could read actual packet data
             using NetworkStream netStream = new(sock, false);
-            using StreamReader reader = new(netStream);
+
             using StreamWriter writer = new(netStream);
             // Send the "HTTP" request
             StringBuilder reqBuilder = new($@"
@@ -47,14 +65,14 @@ CelesteNet-PlayerNameKey: {nameKey}
             writer.Flush();
 
             // Read the "HTTP" response
-            string statusLine = reader.ReadLine();
+            string statusLine = netStream.ReadLine();
             string[] statusSegs = statusLine.Split(new[] { ' ' }, 3);
             if (statusSegs.Length != 3)
                 throw new InvalidDataException($"Invalid HTTP response status line: '{statusLine}'");
             int statusCode = int.Parse(statusSegs[1]);
 
             Dictionary<string, string> headers = new();
-            for (string line = reader.ReadLine(); !string.IsNullOrEmpty(line); line = reader.ReadLine()) {
+            for (string line = netStream.ReadLine(); !string.IsNullOrEmpty(line); line = netStream.ReadLine()) {
                 int split = line.IndexOf(':');
                 if (split == -1)
                     throw new InvalidDataException($"Invalid HTTP header: '{line}'");
@@ -62,7 +80,7 @@ CelesteNet-PlayerNameKey: {nameKey}
             }
 
             string content = "";
-            for (string line = reader.ReadLine(); !string.IsNullOrEmpty(line); line = reader.ReadLine())
+            for (string line = netStream.ReadLine(); !string.IsNullOrEmpty(line); line = netStream.ReadLine())
                 content += line + "\n";
 
             // Parse the "HTTP response"


### PR DESCRIPTION
It's a miracle that this bug is seemingly so rare for people to run into.

But the `StreamReader` class always tries to buffer from its underlying stream, by default up to 1024 bytes.

Usually the "418 I'm a teapot" response sent to the client in the handshake is around 600 to 700 bytes, at least in this case I was debugging with someone. 
And so the `StreamReader` attempts to read the 1024 bytes out of the `NetworkStream`, and we're just all lucky that we get back only the bytes that are available during the handshake, and no further packets have been received from the server yet. Otherwise it starts buffering away the start of the DataTypes on the TCP stream, and then when the handshake is done, we dispose the `StreamReader` and its buffer (which you don't have any control over anyways other than setting its size and telling it to clear, I think...)
And so in this case the `TCPRecvThreadFunc` of `CelesteNetClientTCPUDPConnection` would just start reading the first "random" 2 bytes from the socket and treat them as a data type size and everything obviously is garbage from there :3

So our fix (mostly quickly hacked up by Popax) is to do the "ReadLine" terribly slowly, byte by byte, and not even caring if we split by `\n` or `\r\n`; in the latter case just discard the `\r` at the end of the line. If we ever had any lines that are only using `\r` as line breaks this stuff would definitely break, but noone should ever do such a thing, right.

PS: Don't mind the Extras commit bump, it's just from when I added a readme over there and was too lazy to bump.