### PR TITLE
Fix issue with ParseAndRun when msg.Text doesn't start with command invocation

### DIFF
--- a/CelesteNet.Server.ChatModule/CMDs/CmdBan.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdBan.cs
@@ -7,7 +7,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
     public class CmdBanQ : CmdBan {
 
-        public override string Info => $"Same as {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdBan>().ID} but without Broadcast (quiet)";
+        public override string Info => $"Same as {Chat.Commands.Get<CmdBan>().InvokeString} but without Broadcast (quiet)";
 
         public override bool InternalAliasing => true;
 
@@ -61,9 +61,9 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
             if (!Quiet)
                 new DynamicData(player).Set("leaveReason", chat.Settings.MessageBan);
-            player.Dispose();
             player.Con.Send(new DataDisconnectReason { Text = "Banned: " + ban.Reason });
             player.Con.Send(new DataInternalDisconnect());
+            player.Dispose();
 
             env.Server.UserData.Save(player.UID, ban);
         }

--- a/CelesteNet.Server.ChatModule/CMDs/CmdBroadcast.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdBroadcast.cs
@@ -3,7 +3,7 @@
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
     public class CmdBC : CmdBroadcast {
 
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdBroadcast>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdBroadcast>().InvokeString}";
 
     }
 

--- a/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
     public class CmdJoin : CmdChannel {
 
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdChannel>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdChannel>().InvokeString}";
 
         public override bool InternalAliasing => true;
 
@@ -18,10 +18,10 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
         public override string Info => "Switch to a different channel.";
         public override string Help =>
 $@"Switch to a different channel.
-To list all public channels, {Chat.Settings.CommandPrefix}{ID}
-To create / join a public channel, {Chat.Settings.CommandPrefix}{ID} channel
-To create / join a private channel, {Chat.Settings.CommandPrefix}{ID} {Channels.PrefixPrivate}channel
-To go back to the default channel, {Chat.Settings.CommandPrefix}{ID} {Channels.NameDefault}";
+To list all public channels, {InvokeString}
+To create / join a public channel, {InvokeString} channel
+To create / join a private channel, {InvokeString} {Channels.PrefixPrivate}channel
+To go back to the default channel, {InvokeString} {Channels.NameDefault}";
 
         public const int pageSize = 8;
 
@@ -40,10 +40,10 @@ To go back to the default channel, {Chat.Settings.CommandPrefix}{ID} {Channels.N
         public override void Run(CmdEnv env, List<ICmdArg>? args) {
             CelesteNetPlayerSession? session = env.Session;
             if (session == null)
-                throw new CommandRunException($"Called {Chat.Settings.CommandPrefix}{ID} without player Session.");
+                throw new CommandRunException($"Called {InvokeString} without player Session.");
 
             if (args == null || args.Count == 0)
-                throw new ArgumentException($"Called {Chat.Settings.CommandPrefix}{ID} with no Argument?");
+                throw new ArgumentException($"Called {InvokeString} with no Argument?");
 
             string commandOutput = args[0] switch {
                 CmdArgChannelPage cmdArg => GetChannelPage(env, cmdArg.Int, cmdArg.ChannelList),

--- a/CelesteNet.Server.ChatModule/CMDs/CmdChannelChat.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdChannelChat.cs
@@ -5,7 +5,7 @@ using Celeste.Mod.CelesteNet.DataTypes;
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
     public class CmdCC : CmdChannelChat {
 
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdChannelChat>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdChannelChat>().InvokeString}";
 
     }
 
@@ -15,8 +15,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
         public override string Help =>
 $@"Send a whisper to everyone in the channel or toggle auto channel chat.
-To send a message in the channel, {Chat.Settings.CommandPrefix}{ID} message here
-To enable / disable auto channel chat mode, {Chat.Settings.CommandPrefix}{ID}";
+To send a message in the channel, {InvokeString} message here
+To enable / disable auto channel chat mode, {InvokeString}";
 
         public override void Init(ChatModule chat) {
             Chat = chat;

--- a/CelesteNet.Server.ChatModule/CMDs/CmdEmote.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdEmote.cs
@@ -4,7 +4,7 @@ using Celeste.Mod.CelesteNet.DataTypes;
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
     public class CmdE : CmdEmote {
 
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdEmote>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdEmote>().InvokeString}";
 
     }
 

--- a/CelesteNet.Server.ChatModule/CMDs/CmdGlobalChat.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdGlobalChat.cs
@@ -5,7 +5,7 @@ using Microsoft.Xna.Framework;
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
     public class CmdGC : CmdGlobalChat {
 
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdGlobalChat>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdGlobalChat>().InvokeString}";
 
     }
 
@@ -15,8 +15,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
         public override string Help =>
 $@"Send a message to everyone in the server.
-To send a message, {Chat.Settings.CommandPrefix}{ID} message here
-To enable / disable auto channel chat mode, {Chat.Settings.CommandPrefix}{ID}";
+To send a message, {InvokeString} message here
+To enable / disable auto channel chat mode, {InvokeString}";
 
         public override void Init(ChatModule chat) {
             Chat = chat;

--- a/CelesteNet.Server.ChatModule/CMDs/CmdHelp.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdHelp.cs
@@ -7,7 +7,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
     public class CmdH : CmdHelp {
 
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdHelp>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdHelp>().InvokeString}";
 
 
     }
@@ -21,8 +21,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
         public override int HelpOrder => int.MinValue;
 
         public override string Help =>
-$@"List all commands with {Chat.Settings.CommandPrefix}{ID} [page number]
-Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
+$@"List all commands with {InvokeString} [page number]
+Show help on a command with {InvokeString} <cmd>
 (You did exactly that just now to get here, I assume!)";
 
         public const int pageSize = 8;
@@ -58,8 +58,6 @@ Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
         }
 
        public string GetCommandPage(CmdEnv env, int page = 0) {
-
-            string prefix = Chat.Settings.CommandPrefix;
             StringBuilder builder = new();
 
             List<ChatCmd> all = Chat.Commands.All.Where(cmd =>
@@ -80,8 +78,7 @@ Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
                 if (cmd.ArgParsers.Count > 1 && cmd.ArgParsers.TrueForAll(ap => ap.Parameters.Count == 1)) {
                     // for commands with multiple parsers with single arguments, list them with "|" on one line
                     builder
-                        .Append(prefix)
-                        .Append(cmd.ID)
+                        .Append(cmd.InvokeString)
                         .Append(" ");
 
                     foreach (ArgParser args in parsers) {
@@ -98,8 +95,7 @@ Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
                     // otherwise, list all the parsers on separate lines
                     foreach (ArgParser args in parsers) {
                         builder
-                            .Append(prefix)
-                            .Append(cmd.ID)
+                            .Append(cmd.InvokeString)
                             .Append(" ")
                             .Append(args.ToString())
                             .AppendLine();
@@ -107,8 +103,7 @@ Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
                 } else {
                     // or just this when there's not even ArgParsers
                     builder
-                        .Append(prefix)
-                        .Append(cmd.ID)
+                        .Append(cmd.InvokeString)
                         .AppendLine();
                 }
             }
@@ -137,7 +132,6 @@ Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
         }
 
         public string Help_GetCommandSnippet(ChatCmd cmd) {
-            string prefix = Chat.Settings.CommandPrefix;
             StringBuilder builder = new();
             StringBuilder builderSyntax = new();
             StringBuilder builderExamples = new();
@@ -145,14 +139,12 @@ Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
             IOrderedEnumerable<ArgParser> parsers = cmd.ArgParsers.OrderBy(ap => ap.HelpOrder);
             foreach (ArgParser args in parsers) {
                 builderSyntax
-                    .Append(prefix)
-                    .Append(cmd.ID)
+                    .Append(cmd.InvokeString)
                     .Append(" ")
                     .Append(args.ToString())
                     .AppendLine();
                 builderExamples
-                    .Append(prefix)
-                    .Append(cmd.ID)
+                    .Append(cmd.InvokeString)
                     .Append(" ")
                     .Append(args.ToExample())
                     .AppendLine();
@@ -160,8 +152,7 @@ Show help on a command with {Chat.Settings.CommandPrefix}{ID} <cmd>
 
             if (cmd.ArgParsers.Count == 0) {
                 builderSyntax
-                    .Append(prefix)
-                    .Append(cmd.ID)
+                    .Append(cmd.InvokeString)
                     .AppendLine();
             }
 

--- a/CelesteNet.Server.ChatModule/CMDs/CmdKick.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdKick.cs
@@ -5,7 +5,7 @@ using MonoMod.Utils;
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
     public class CmdKickQ : CmdKick {
 
-        public override string Info => $"Same as {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdKick>().ID} but without Broadcast (quiet)";
+        public override string Info => $"Same as {Chat.Commands.Get<CmdKick>().InvokeString} but without Broadcast (quiet)";
 
         public override bool InternalAliasing => true;
 
@@ -42,9 +42,9 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
             if (!Quiet)
                 new DynamicData(player).Set("leaveReason", Chat.Settings.MessageKick);
-            player.Dispose();
             player.Con.Send(new DataDisconnectReason { Text = "Kicked" });
             player.Con.Send(new DataInternalDisconnect());
+            player.Dispose();
         }
 
     }

--- a/CelesteNet.Server.ChatModule/CMDs/CmdReply.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdReply.cs
@@ -3,7 +3,7 @@
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
     public class CmdR : CmdReply {
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdReply>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdReply>().InvokeString}";
     }
 
     public class CmdReply : ChatCmd {

--- a/CelesteNet.Server.ChatModule/CMDs/CmdWhisper.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdWhisper.cs
@@ -4,7 +4,7 @@ using Celeste.Mod.CelesteNet.DataTypes;
 namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
     public class CmdW : CmdWhisper {
 
-        public override string Info => $"Alias for {Chat.Settings.CommandPrefix}{Chat.Commands.Get<CmdWhisper>().ID}";
+        public override string Info => $"Alias for {Chat.Commands.Get<CmdWhisper>().InvokeString}";
 
     }
 
@@ -16,8 +16,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
         public override string Help =>
 $@"Send a whisper to someone else or toggle whispers.
-To send a whisper to someone, {Chat.Settings.CommandPrefix}{ID} user text
-To enable / disable whispers being sent to you, {Chat.Settings.CommandPrefix}{ID}";
+To send a whisper to someone, {InvokeString} user text
+To enable / disable whispers being sent to you, {InvokeString}";
 
         public override void Init(ChatModule chat) {
             Chat = chat;

--- a/CelesteNet.Server.ChatModule/CMDs/CommandsContext.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CommandsContext.cs
@@ -180,12 +180,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
         }
 
         public virtual void ParseAndRun(CmdEnv env, ArgParser? parser) {
-            string raw = env.FullText;
-
-            if (raw.StartsWith(InvokeString))
-                raw = raw.Substring(InvokeString.Length);
-
-            List<ICmdArg>? args = parser?.Parse(raw, env);
+            List<ICmdArg>? args = parser?.Parse(env.Text, env);
 
             Run(env, args);
         }
@@ -243,6 +238,15 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
         public bool IsAuthorizedExec => !(Session?.UID?.IsNullOrEmpty() ?? true) && Chat.Server.UserData.TryLoad(Session.UID, out BasicUserInfo info) && info.Tags.Contains(BasicUserInfo.TAG_AUTH_EXEC);
 
         public string FullText => Msg.Text;
+        public string Text {
+            get {
+                if (Cmd == null || !Msg.Text.StartsWith(Cmd.InvokeString)) {
+                    return Msg.Text;
+                } else {
+                    return Msg.Text.Substring(Cmd.InvokeString.Length);
+                }
+            }
+        }
 
         public DataChat? Send(string text, string? tag = null, Color? color = null) => Chat.SendTo(Session, text, tag, color ?? Chat.Settings.ColorCommandReply);
 

--- a/CelesteNet.Server.ChatModule/CMDs/CommandsContext.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CommandsContext.cs
@@ -83,6 +83,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
         public virtual string ID => GetType().Name.Substring(3).ToLowerInvariant();
 
+        public string InvokeString => Chat.Settings.CommandPrefix + ID;
+
         public abstract string Info { get; }
         public virtual string Help => Info;
         public virtual int HelpOrder => 0;
@@ -178,7 +180,10 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
         }
 
         public virtual void ParseAndRun(CmdEnv env, ArgParser? parser) {
-            string raw = env.FullText.Substring(Chat.Settings.CommandPrefix.Length + ID.Length);
+            string raw = env.FullText;
+
+            if (raw.StartsWith(InvokeString))
+                raw = raw.Substring(InvokeString.Length);
 
             List<ICmdArg>? args = parser?.Parse(raw, env);
 
@@ -238,7 +243,6 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
         public bool IsAuthorizedExec => !(Session?.UID?.IsNullOrEmpty() ?? true) && Chat.Server.UserData.TryLoad(Session.UID, out BasicUserInfo info) && info.Tags.Contains(BasicUserInfo.TAG_AUTH_EXEC);
 
         public string FullText => Msg.Text;
-        public string Text => Cmd == null ? Msg.Text : Msg.Text.Substring(Chat.Settings.CommandPrefix.Length + Cmd.ID.Length);
 
         public DataChat? Send(string text, string? tag = null, Color? color = null) => Chat.SendTo(Session, text, tag, color ?? Chat.Settings.ColorCommandReply);
 

--- a/CelesteNet.Server.ChatModule/CMDs/ParamArgs/ParamChannelPage.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ParamArgs/ParamChannelPage.cs
@@ -18,10 +18,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
             if (parseSuccess || string.IsNullOrWhiteSpace(raw)) {
 
                 if (channels.All.Count == 0) {
-                    // NB: No point in getting ChatCMDChannel.ID since that's not static - you could
-                    // call Chat.Commands.Get("channel").ID or Chat.Commands.Get<ChatCMDChannel>().ID
-                    // but that's just a longer way of spelling it out :)
-                    throw new ParamException($"No channels. See {Chat.Settings.CommandPrefix}channel on how to create one.");
+                    throw new ParamException($"No channels. See {Chat.Commands.Get<CmdChannel>().InvokeString} on how to create one.");
                 }
 
                 if (parseSuccess)

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -152,7 +152,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
 
                 CmdEnv env = new(this, msg);
 
-                string cmdName = env.FullText.Substring(Settings.CommandPrefix.Length);
+                string cmdName = msg.Text.Substring(Settings.CommandPrefix.Length);
                 cmdName = cmdName.Split(ChatCmd.NameDelimiters)[0].ToLowerInvariant();
                 if (cmdName.Length == 0)
                     return;

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDBan.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDBan.cs
@@ -54,9 +54,9 @@ namespace Celeste.Mod.CelesteNet.Server.Control
                     ChatModule chat = Frontend.Server.Get<ChatModule>();
                     if (!quiet)
                         new DynamicData(player).Set("leaveReason", chat.Settings.MessageBan);
-                    player.Dispose();
                     player.Con.Send(new DataDisconnectReason { Text = "Banned: " + reason });
                     player.Con.Send(new DataInternalDisconnect());
+                    player.Dispose();
                 }
             }
 

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
@@ -14,9 +14,9 @@ namespace Celeste.Mod.CelesteNet.Server.Control
 
             ChatModule chat = Frontend.Server.Get<ChatModule>();
             new DynamicData(player).Set("leaveReason", chat.Settings.MessageKick);
-            player.Dispose();
             player.Con.Send(new DataDisconnectReason { Text = "Kicked" });
             player.Con.Send(new DataInternalDisconnect());
+            player.Dispose();
             return true;
         }
     }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKickWarn.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKickWarn.cs
@@ -20,9 +20,9 @@ namespace Celeste.Mod.CelesteNet.Server.Control
             ChatModule chat = Frontend.Server.Get<ChatModule>();
             if (!quiet)
                 new DynamicData(player).Set("leaveReason", chat.Settings.MessageKick);
-            player.Dispose();
             player.Con.Send(new DataDisconnectReason { Text = string.IsNullOrEmpty(reason) ? "Kicked" : $"Kicked: {reason}" });
             player.Con.Send(new DataInternalDisconnect());
+            player.Dispose();
 
             Logger.Log(LogLevel.VVV, "frontend", $"Player kicked with reason:\n{id} => {uid} (q: {quiet})\nReason: {reason}");
 


### PR DESCRIPTION
Hotfix for #109 breaking auto-cc

Also, refactor string interpolation uses of Chat.Settings.CommandPrefix to make it easier to search for actual uses of it within string manipulating logic.