### PR TITLE
ChatModule apply optional filtering

### DIFF
--- a/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
@@ -90,7 +90,14 @@ To go back to the default channel, {InvokeString} {Channels.NameDefault}";
             if ((Chat.Settings.FilterPrivateChannelNames || !channel.StartsWith(Channels.PrefixPrivate)) && Chat.Settings.FilterChannelNames != FilterHandling.None) {
                 FilterHandling check = Chat.ContainsFilteredWord(channel);
                 if (check != FilterHandling.None && Chat.Settings.FilterChannelNames.HasFlag(check)) {
-                    Chat.InvokeOnApplyFilter(new ChatModule.FilterDecision(session.PlayerInfo) { Handling = FilterHandling.Drop, chatTag = channel, chatText = env.FullText });
+                    var decision = new FilterDecision(session.PlayerInfo)
+                    {
+                        Handling = FilterHandling.Drop,
+                        Cause = FilterDecisionCause.ChannelName,
+                        chatTag = channel,
+                        chatText = env.FullText
+                    };
+                    Chat.InvokeOnApplyFilter(decision);
                     throw new CommandRunException("Channel name not allowed.");
                 }
             }

--- a/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
@@ -87,6 +87,13 @@ To go back to the default channel, {InvokeString} {Channels.NameDefault}";
         }
 
         public string SwitchChannel(CmdEnv env, CelesteNetPlayerSession session, string channel) {
+            if ((Chat.Settings.FilterPrivateChannelNames || !channel.StartsWith(Channels.PrefixPrivate)) && Chat.Settings.FilterChannelNames != FilterHandling.None) {
+                FilterHandling check = Chat.ContainsFilteredWord(channel);
+                if (check != FilterHandling.None && Chat.Settings.FilterChannelNames.HasFlag(check)) {
+                    throw new CommandRunException("Channel name not allowed.");
+                }
+            }
+
             try {
                 Tuple<Channel, Channel> tuple = env.Server.Channels.Move(session, channel);
                 return tuple.Item1 == tuple.Item2 ? $"Already in {tuple.Item2.Name}" : $"Moved to {tuple.Item2.Name}";

--- a/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
@@ -90,6 +90,7 @@ To go back to the default channel, {InvokeString} {Channels.NameDefault}";
             if ((Chat.Settings.FilterPrivateChannelNames || !channel.StartsWith(Channels.PrefixPrivate)) && Chat.Settings.FilterChannelNames != FilterHandling.None) {
                 FilterHandling check = Chat.ContainsFilteredWord(channel);
                 if (check != FilterHandling.None && Chat.Settings.FilterChannelNames.HasFlag(check)) {
+                    Chat.InvokeOnApplyFilter(new ChatModule.FilterDecision(session.PlayerInfo) { Handling = FilterHandling.Drop, chatTag = channel, chatText = env.FullText });
                     throw new CommandRunException("Channel name not allowed.");
                 }
             }

--- a/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs
@@ -90,14 +90,12 @@ To go back to the default channel, {InvokeString} {Channels.NameDefault}";
             if ((Chat.Settings.FilterPrivateChannelNames || !channel.StartsWith(Channels.PrefixPrivate)) && Chat.Settings.FilterChannelNames != FilterHandling.None) {
                 FilterHandling check = Chat.ContainsFilteredWord(channel);
                 if (check != FilterHandling.None && Chat.Settings.FilterChannelNames.HasFlag(check)) {
-                    var decision = new FilterDecision(session.PlayerInfo)
-                    {
+                    Chat.InvokeOnApplyFilter(new FilterDecision(session.PlayerInfo) {
                         Handling = FilterHandling.Drop,
                         Cause = FilterDecisionCause.ChannelName,
                         chatTag = channel,
                         chatText = env.FullText
-                    };
-                    Chat.InvokeOnApplyFilter(decision);
+                    });
                     throw new CommandRunException("Channel name not allowed.");
                 }
             }

--- a/CelesteNet.Server.ChatModule/CMDs/CmdChannelChat.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdChannelChat.cs
@@ -59,6 +59,11 @@ To enable / disable auto channel chat mode, {InvokeString}";
             if (msg == null)
                 return;
 
+            if (channel.Name == Channels.NameDefault || !Chat.Settings.FilterOnlyGlobalAndMainChat) {
+                if (Chat.ApplyFilterHandling(session, msg) != FilterHandling.None)
+                    return;
+            }
+
             if (player != null) {
                 env.Msg.Tag = $"channel {channel.Name}";
                 env.Msg.Text = argMsg;

--- a/CelesteNet.Server.ChatModule/CMDs/CmdGlobalChat.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdGlobalChat.cs
@@ -47,6 +47,9 @@ To enable / disable auto channel chat mode, {InvokeString}";
             if (msg == null)
                 return;
 
+            if (Chat.ApplyFilterHandling(env.Session, msg) != FilterHandling.None)
+                return;
+
             env.Msg.Text = argMsg;
             env.Msg.Tag = "";
             env.Msg.Color = Color.White;

--- a/CelesteNet.Server.ChatModule/CMDs/CmdGlobalChat.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdGlobalChat.cs
@@ -46,7 +46,7 @@ To enable / disable auto channel chat mode, {Chat.Settings.CommandPrefix}{ID}";
             env.Msg.Text = text;
             env.Msg.Tag = "";
             env.Msg.Color = Color.White;
-            env.Msg.Target = null;
+            env.Msg.Targets = null;
             Chat.ForceSend(env.Msg);
         }
 

--- a/CelesteNet.Server.ChatModule/CMDs/CmdKick.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdKick.cs
@@ -42,7 +42,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
             if (!Quiet)
                 new DynamicData(player).Set("leaveReason", Chat.Settings.MessageKick);
-            player.Con.Send(new DataDisconnectReason { Text = "Kicked" });
+            player.Con.Send(new DataDisconnectReason { Text = Chat.Settings.MessageDefaultKickReason });
             player.Con.Send(new DataInternalDisconnect());
             player.Dispose();
         }

--- a/CelesteNet.Server.ChatModule/CMDs/CmdWhisper.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdWhisper.cs
@@ -63,7 +63,7 @@ To enable / disable whispers being sent to you, {Chat.Settings.CommandPrefix}{ID
 
             other.Con.Send(Chat.PrepareAndLog(null, new DataChat {
                 Player = player,
-                Target = otherPlayer,
+                Targets = [otherPlayer],
                 Tag = "whisper",
                 Text = text,
                 Color = Chat.Settings.ColorWhisper

--- a/CelesteNet.Server.ChatModule/CMDs/ParamArgs/ParamPlayerSession.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ParamArgs/ParamPlayerSession.cs
@@ -36,7 +36,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
                         // check for partial name elsewhere
                         env.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(raw, StringComparison.InvariantCultureIgnoreCase) ?? false);
                 }
-            } else if (uint.TryParse(raw, out playerID)) {
+            }
+            if (session == null && uint.TryParse(raw, out playerID)) {
                 Chat.Server.PlayersByID.TryGetValue(playerID, out session);
             }
 

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -131,7 +131,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         }
 
         public event Action<ChatModule, FilterDecision>? OnApplyFilter;
-
+        // I'm sure having this extra method is a crime but who's gonna stop me (using this in CmdChannel when filtering channel names)
         public void InvokeOnApplyFilter(FilterDecision chatFilterDecision) => OnApplyFilter?.Invoke(this, chatFilterDecision);
 
         public FilterHandling ApplyFilterHandling(CelesteNetPlayerSession session, DataChat msg, FilterHandling filterAs = FilterHandling.None) {

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -353,7 +353,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
 
             OnReceive?.Invoke(this, msg);
 
-            if (msg.Targets == null){
+            if (msg.Targets == null) {
                 Server.BroadcastAsync(msg);
                 return;
             }
@@ -402,8 +402,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
             return msg;
         }
 
-        public void Broadcast(DataChat msg)
-        {
+        public void Broadcast(DataChat msg) {
             Logger.Log(LogLevel.INF, "chat", $"Broadcasting: {msg.Text}");
             Handle(null, msg);
         }
@@ -450,39 +449,39 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
             public bool AutoChannelChat { get; set; } = false;
             public bool Whispers { get; set; } = true;
         }
-
-        public enum FilterDecisionCause {
-            Chat = 0,
-            UserName = 1,
-            ChannelName = 2,
-        }
-
-        public class FilterDecision {
-            public FilterHandling Handling { get; set; } = FilterHandling.None;
-            public FilterDecisionCause Cause { get; set; } = FilterDecisionCause.Chat;
-            public uint chatID { get; set; } = uint.MaxValue;
-            public string chatTag { get; set; } = string.Empty;
-            public string chatText { get; set; } = string.Empty;
-
-            public string playerName { get; set; } = string.Empty;
-            public uint playerID { get; set; } = uint.MaxValue;
-
-            public FilterDecision() {
-            }
-
-            public FilterDecision(DataPlayerInfo? player) {
-                playerID = player?.ID ?? uint.MaxValue;
-                playerName = player?.FullName ?? "";
-            }
-
-            public FilterDecision(DataChat fromChat) {
-                chatID = fromChat.ID;
-                chatTag = fromChat.Tag;
-                chatText = fromChat.Text;
-                playerID = fromChat.Player?.ID ?? uint.MaxValue;
-                playerName = fromChat.Player?.FullName ?? "";
-            }
-        }
-
     }
+
+    public enum FilterDecisionCause {
+        Chat = 0,
+        UserName = 1,
+        ChannelName = 2,
+    }
+
+    public class FilterDecision {
+        public FilterHandling Handling { get; set; } = FilterHandling.None;
+        public FilterDecisionCause Cause { get; set; } = FilterDecisionCause.Chat;
+        public uint chatID { get; set; } = uint.MaxValue;
+        public string chatTag { get; set; } = string.Empty;
+        public string chatText { get; set; } = string.Empty;
+
+        public string playerName { get; set; } = string.Empty;
+        public uint playerID { get; set; } = uint.MaxValue;
+
+        public FilterDecision() {
+        }
+
+        public FilterDecision(DataPlayerInfo? player) {
+            playerID = player?.ID ?? uint.MaxValue;
+            playerName = player?.FullName ?? "";
+        }
+
+        public FilterDecision(DataChat fromChat) {
+            chatID = fromChat.ID;
+            chatTag = fromChat.Tag;
+            chatText = fromChat.Text;
+            playerID = fromChat.Player?.ID ?? uint.MaxValue;
+            playerName = fromChat.Player?.FullName ?? "";
+        }
+    }
+
 }

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -28,8 +28,6 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public override void Init(CelesteNetServerModuleWrapper wrapper) {
             base.Init(wrapper);
 
-            UpdateFilterLists();
-
             BroadcastSpamContext = new(this);
             Commands = new(this);
             Server.OnSessionStart += OnSessionStart;
@@ -44,7 +42,17 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
             UpdateFilterLists();
         }
 
+        public override void LoadSettings() {
+            base.LoadSettings();
+
+            UpdateFilterLists();
+        }
+
         public void UpdateFilterLists() {
+            filterDrop.Clear();
+            filterKick.Clear();
+            filterWarnOnce.Clear();
+
             if (Settings.FilterDrop != null) {
                 foreach (string word in Settings.FilterDrop) {
                     filterDrop.Add(word.ToLower().Trim());

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Celeste.Mod.CelesteNet.DataTypes;
 using Celeste.Mod.CelesteNet.Server.Chat.Cmd;
@@ -22,9 +20,9 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public CommandsContext Commands;
 #pragma warning restore CS8618
 
-        private HashSet<string> filterDrop = new HashSet<string>();
-        private HashSet<string> filterKick = new HashSet<string>();
-        private HashSet<string> filterWarnOnce = new HashSet<string>();
+        private HashSet<string> filterDrop = new();
+        private HashSet<string> filterKick = new();
+        private HashSet<string> filterWarnOnce = new();
 
         public override void Init(CelesteNetServerModuleWrapper wrapper) {
             base.Init(wrapper);
@@ -165,7 +163,6 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
             FilterHandling handledAs = FilterHandling.None;
 
             if (filterAs.HasFlag(FilterHandling.Kick)) {
-                Logger.Log(LogLevel.INF, "word-filter", $"Message '{msg.Text}' triggered Kick handling. ({filterAs})");
                 session.Con.Send(new DataDisconnectReason { Text = $"Disconnected: " + Settings.MessageDefaultKickReason });
                 session.Con.Send(new DataInternalDisconnect());
                 session.Dispose();

--- a/CelesteNet.Server.ChatModule/ChatSettings.cs
+++ b/CelesteNet.Server.ChatModule/ChatSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
+using System.Collections.Generic;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
     public class ChatSettings : CelesteNetServerModuleSettings {
@@ -15,6 +16,10 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public int SpamCountMax { get; set; } = 4;
         public double SpamTimeout { get; set; } = 4;
         public double SpamTimeoutAdd { get; set; } = 5;
+
+        public List<string> FilterDrop {  get; set; } = new List<string>();
+        public List<string> FilterKick { get; set; } = new List<string>();
+        public List<string> FilterWarnOnce { get; set; } = new List<string>();
 
         public Color ColorBroadcast { get; set; } = Calc.HexToColor("#00adee");
         public Color ColorServer { get; set; } = Calc.HexToColor("#9e24f5");

--- a/CelesteNet.Server.ChatModule/ChatSettings.cs
+++ b/CelesteNet.Server.ChatModule/ChatSettings.cs
@@ -23,7 +23,8 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public List<string> FilterWarnOnce { get; set; } = new List<string>();
         public FilterHandling FilterPlayerNames { get; set; } = FilterHandling.Drop | FilterHandling.Kick;
         public FilterHandling FilterChannelNames { get; set; } = FilterHandling.Drop | FilterHandling.Kick;
-        public bool FilterOnlyGlobalAndMain { get; set; } = true;
+        public bool FilterOnlyGlobalAndMainChat { get; set; } = true;
+        public bool FilterPrivateChannelNames { get; set; } = false;
 
         public Color ColorBroadcast { get; set; } = Calc.HexToColor("#00adee");
         public Color ColorServer { get; set; } = Calc.HexToColor("#9e24f5");
@@ -40,9 +41,10 @@ Press T to talk.
 Send /help for a list of all commands.";
         public string MessageLeave { get; set; } = "Cya, {player}!";
         public string MessageKick { get; set; } = "{player} did an oopsie!";
+        public string MessageDefaultKickReason { get; set; } = "Kicked";
         public string MessageBan { get; set; } = "{player} won't come back.";
         public string MessageSpam { get; set; } = "Stop spamming.";
-
+        public string MessageWarnOnce { get; set; } = "Your message may be in violation of CNet rules. Send it again if you're sure it's acceptable, and it will go through. May be subjected to review.";
     }
 
     [Flags]

--- a/CelesteNet.Server.ChatModule/ChatSettings.cs
+++ b/CelesteNet.Server.ChatModule/ChatSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
+using System;
 using System.Collections.Generic;
 
 namespace Celeste.Mod.CelesteNet.Server.Chat {
@@ -20,6 +21,9 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
         public List<string> FilterDrop {  get; set; } = new List<string>();
         public List<string> FilterKick { get; set; } = new List<string>();
         public List<string> FilterWarnOnce { get; set; } = new List<string>();
+        public FilterHandling FilterPlayerNames { get; set; } = FilterHandling.Drop | FilterHandling.Kick;
+        public FilterHandling FilterChannelNames { get; set; } = FilterHandling.Drop | FilterHandling.Kick;
+        public bool FilterOnlyGlobalAndMain { get; set; } = true;
 
         public Color ColorBroadcast { get; set; } = Calc.HexToColor("#00adee");
         public Color ColorServer { get; set; } = Calc.HexToColor("#9e24f5");
@@ -39,5 +43,13 @@ Send /help for a list of all commands.";
         public string MessageBan { get; set; } = "{player} won't come back.";
         public string MessageSpam { get; set; } = "Stop spamming.";
 
+    }
+
+    [Flags]
+    public enum FilterHandling {
+        None = 0,
+        WarnOnce = 1,
+        Drop = 2,
+        Kick = 4,
     }
 }

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -130,12 +130,12 @@ namespace Celeste.Mod.CelesteNet.Server.Control
         }
 
         private void OnSessionStart(CelesteNetPlayerSession session) {
-            if (session.Alive) {
-                Broadcast(frontendWS => frontendWS.SendCommand(
-                    "sess_join", PlayerSessionToFrontend(session, frontendWS.IsAuthorized, true)
-                ));
-                TryBroadcastUpdate(Settings.APIPrefix + "/status");
-            }
+            if (!session.Alive)
+                return;
+            Broadcast(frontendWS => frontendWS.SendCommand(
+                "sess_join", PlayerSessionToFrontend(session, frontendWS.IsAuthorized, true)
+            ));
+            TryBroadcastUpdate(Settings.APIPrefix + "/status");
             //TryBroadcastUpdate(Settings.APIPrefix + "/players");
             session.OnEnd += OnSessionEnd;
         }

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -67,6 +67,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control
 
             ChatModule chat = Server.Get<ChatModule>();
             chat.OnReceive += OnChatReceive;
+            chat.OnApplyFilter += OnChatFilter;
             chat.OnForceSend += OnForceSend;
         }
 
@@ -119,6 +120,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control
 
             if (Server.TryGet(out ChatModule? chat)) {
                 chat.OnReceive -= OnChatReceive;
+                chat.OnApplyFilter -= OnChatFilter;
                 chat.OnForceSend -= OnForceSend;
             }
         }
@@ -186,6 +188,17 @@ namespace Celeste.Mod.CelesteNet.Server.Control
 
         private void OnChatReceive(ChatModule chat, DataChat msg) {
             BroadcastCMD(msg.Targets != null, "chat", msg.ToDetailedFrontendChat());
+        }
+
+        private void OnChatFilter(ChatModule chat, DataChat msg, FilterHandling handled) {
+            BroadcastCMD(true, "filter", new {
+                msg.ID,
+                PlayerID = msg.Player?.ID ?? uint.MaxValue,
+                Name = msg.Player?.FullName ?? string.Empty,
+                Targets = msg.Targets?.Select(p => p?.ID ?? uint.MaxValue) ?? null,
+                msg.Text,
+                Handling = handled.ToString()
+            });
         }
 
         private void OnForceSend(ChatModule chat, DataChat msg) {

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -192,7 +192,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control
             BroadcastCMD(msg.Targets != null, "chat", msg.ToDetailedFrontendChat());
         }
 
-        private void OnChatFilter(ChatModule chat, ChatModule.FilterDecision chatFilterDecision) {
+        private void OnChatFilter(ChatModule chat, FilterDecision chatFilterDecision) {
             BroadcastCMD(true, "filter", new {
                 // bit annoying but I'd rather have the enum values as strings in the JSON rather than ints
                 Handling = chatFilterDecision.Handling.ToString(),

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -1,20 +1,19 @@
-﻿using Microsoft.AspNetCore.StaticFiles;
+﻿using Celeste.Mod.CelesteNet.DataTypes;
+using Celeste.Mod.CelesteNet.Server.Chat;
+using Microsoft.AspNetCore.StaticFiles;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using WebSocketSharp.Server;
-using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CelesteNet.Server.Chat;
 using System.Timers;
-using System.Dynamic;
+using WebSocketSharp.Server;
 
-namespace Celeste.Mod.CelesteNet.Server.Control
-{
+namespace Celeste.Mod.CelesteNet.Server.Control {
     public class Frontend : CelesteNetServerModule<FrontendSettings> {
 
         public static readonly string COOKIE_SESSION = "celestenet-session";
@@ -197,11 +196,13 @@ namespace Celeste.Mod.CelesteNet.Server.Control
                 // bit annoying but I'd rather have the enum values as strings in the JSON rather than ints
                 Handling = chatFilterDecision.Handling.ToString(),
                 Cause = chatFilterDecision.Cause.ToString(),
-                chatFilterDecision.chatID,
-                chatFilterDecision.chatText,
-                chatFilterDecision.chatTag,
-                chatFilterDecision.playerID,
-                chatFilterDecision.playerName
+
+                PlayerID = chatFilterDecision.playerID,
+                Name = chatFilterDecision.playerName,
+
+                MsgID = chatFilterDecision.chatID,
+                Text = chatFilterDecision.chatText,
+                Tag = chatFilterDecision.chatTag
             });
         }
 

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -432,7 +432,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control
                     using (StreamReader sr = new(c.Request.InputStream, Encoding.UTF8, false, 1024, true))
                         settings.Load(sr);
                     if (module != null) {
-                        // necessary to trigegr subclass overrides of this like in SqliteModule
+                        // necessary to trigger subclass overrides of this like in SqliteModule
                         module.SaveSettings();
                     } else {
                         settings.Save();

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKick.cs
@@ -14,7 +14,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control
 
             ChatModule chat = Frontend.Server.Get<ChatModule>();
             new DynamicData(player).Set("leaveReason", chat.Settings.MessageKick);
-            player.Con.Send(new DataDisconnectReason { Text = "Kicked" });
+            player.Con.Send(new DataDisconnectReason { Text = chat.Settings.MessageDefaultKickReason });
             player.Con.Send(new DataInternalDisconnect());
             player.Dispose();
             return true;

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKickWarn.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDKickWarn.cs
@@ -20,7 +20,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control
             ChatModule chat = Frontend.Server.Get<ChatModule>();
             if (!quiet)
                 new DynamicData(player).Set("leaveReason", chat.Settings.MessageKick);
-            player.Con.Send(new DataDisconnectReason { Text = string.IsNullOrEmpty(reason) ? "Kicked" : $"Kicked: {reason}" });
+            player.Con.Send(new DataDisconnectReason { Text = string.IsNullOrEmpty(reason) ? chat.Settings.MessageDefaultKickReason : $"Kicked: {reason}" });
             player.Con.Send(new DataInternalDisconnect());
             player.Dispose();
 

--- a/CelesteNet.Shared/DataTypes/DataChat.cs
+++ b/CelesteNet.Shared/DataTypes/DataChat.cs
@@ -22,9 +22,33 @@ namespace Celeste.Mod.CelesteNet.DataTypes
         /// <summary>
         /// Server-internal field.
         /// </summary>
+        [Obsolete("Use TryGetSingleTarget instead of this getter, do `Targets = [value]` instead of this setter.", false)]
         public DataPlayerInfo? Target {
-            get => Targets != null && Targets.Length == 1 ? Targets[0] : null;
-            set => Targets = value == null ? null : new DataPlayerInfo[] { value };
+            get {
+                if (Targets != null && Targets.Length == 1) {
+                    return Targets[0];
+                } else {
+                    return null;
+                }
+            }
+
+            set {
+                if (value == null) {
+                    Targets = null;
+                } else {
+                    Targets = [value];
+                }
+            }
+        }
+
+        public bool TryGetSingleTarget(out DataPlayerInfo? target) {
+            if (Targets != null && Targets.Length == 1) {
+                target = Targets[0];
+                return true;
+            }
+
+            target = null;
+            return false;
         }
 
         public DataPlayerInfo? Player;
@@ -76,9 +100,29 @@ namespace Celeste.Mod.CelesteNet.DataTypes
         public override string ToString()
             => ToString(true, false);
 
-        public string ToString(bool displayName, bool id)
-            => $"{(id ? $"{{{ID}v{Version}}} " : "")}{(Tag.IsNullOrEmpty() ? "" : $"[{Tag}] ")}{(displayName ? Player?.DisplayName : Player?.FullName) ?? "**SERVER**"}{(Target != null ? " @ " + Target.DisplayName : "")}:{(Text.IndexOf('\n') != -1 ? "\n" : " ")}{Text}";
 
+        public string ToString(bool useDisplayName, bool withID) {
+            string id = "";
+            if (withID)
+                id = $"{{{ID}v{Version}}}";
 
+            string tag = "";
+            if (!Tag.IsNullOrEmpty())
+                tag = $"[{Tag}]";
+
+            string? username = useDisplayName ? Player?.DisplayName : Player?.FullName;
+            username ??= "**SERVER**";
+
+            if (TryGetSingleTarget(out DataPlayerInfo? target) && target != null)
+                username += " @ " + target.DisplayName;
+
+            string prefix = $"{id} {tag} {username}:".TrimStart();
+
+            if (Text.IndexOf('\n') == -1) {
+                return $"{prefix} {Text}";
+            } else {
+                return $"{prefix}\n{Text}";
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds settings to ChatModule:

```cs
public List<string> FilterDrop {  get; set; } = new();
public List<string> FilterKick { get; set; } = new();
public List<string> FilterWarnOnce { get; set; } = new();

public FilterHandling FilterPlayerNames { get; set; } = FilterHandling.Drop | FilterHandling.Kick;
public FilterHandling FilterChannelNames { get; set; } = FilterHandling.Drop | FilterHandling.Kick;

public bool FilterOnlyGlobalAndMainChat { get; set; } = true;
public bool FilterPrivateChannelNames { get; set; } = false;

[Flags]
public enum FilterHandling {
    None = 0,
    WarnOnce = 1,
    Drop = 2,
    Kick = 4,
}
```
1. Three **lists of strings**, these will be read in as lowercase and trimmed. There's three hard-coded filter modes as described below.
2. Flags for which of the lists should apply to **player names** & **channel names** - matches will always result in "rejecting" the attempt to join with that name/join that channel.
3. bool for whether to only filter chat within main & global chat.
4. bool for whether to apply filtering to private channel names.

Filters are applied/tested in the order Kick -> Drop -> WarnOnce.

## FilterKick

Player will be kicked with a generic kick message, no broadcast of course, and the offending chat message is dropped.

## FilterDrop

The chat message is dropped silently; it does get acknowledged to the player just to clear it from being stuck "Pending" in the client. To the offending player it looks like the message sent normally, but no one else will see it.

## FilterWarnOnce

Upon triggering this filter list, an error message is shown to the player in chat, warning them that they may be about to break the rules. But they can send the exact same message again (arrow up in chat, etc.) and it will go through. Intended to dissuade more ambiguous but very-probably not-rule-conforming language on CelesteNet, or to generally leave a loophole rather than full censorship. /shrug

## WS cmd for Frontend

<details>

<summary>new WS cmd for Frontend & others</summary>
--

There's a new command sent out on the websocket to the JS frontend, with the name **"filter"**. 
```cs
BroadcastCMD(true, "filter", new {
    // bit annoying but I'd rather have the enum values as strings in the JSON rather than ints
    Handling = chatFilterDecision.Handling.ToString(),
    Cause = chatFilterDecision.Cause.ToString(),

    PlayerID = chatFilterDecision.playerID,
    Name = chatFilterDecision.playerName,

    MsgID = chatFilterDecision.chatID,
    Text = chatFilterDecision.chatText,
    Tag = chatFilterDecision.chatTag
});
```
And the "Cause" enum for reference
```cs
public enum FilterDecisionCause {
    Chat = 0,
    UserName = 1,
    ChannelName = 2,
}
```

Some examples for the causes:
```js
{
    Handling: "Drop",
    Cause: "Chat",

    playerID: 1234,
    playerName: "pants",

    MsgID: 123545,
    Text: "literally1984",
    Tag: ""
}
```
There will be no relevant "message" info when caused by a username joining
```js
{
    Handling: "Kick",
    Cause: "UserName",

    playerID: 1234,
    playerName: "pants",

    MsgID: uint.MaxValue,
    Text: "",
    Tag: ""
}
```
For "ChannelName", Text will be the command invocation and Tag will be the offending name
```js
{
    Handling: "Kick",
    Cause: "ChannelName",

    playerID: 1234,
    playerName: "pants",

    MsgID: 123547,
    Text: "/join literally1984",
    Tag: "literally1984"
}
```
</details>