### PR TITLE
Fix some issues with sessions getting dc'd during handshake

### DIFF
--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -128,6 +128,8 @@ namespace Celeste.Mod.CelesteNet.Server.Control
         }
 
         private void OnSessionStart(CelesteNetPlayerSession session) {
+            if (!session.Alive)
+                return;
             Broadcast(frontendWS => frontendWS.SendCommand(
                 "sess_join", PlayerSessionToFrontend(session, frontendWS.IsAuthorized, true)
             ));


### PR DESCRIPTION
They were still showing up on server Frontend and potentially mess up others (Exceptions in clients because of "unknown" session IDs as MetaRefs in DataTypes)