### PR TITLE
Disconnect with chat open makes all inputs unresponsive?... Oops.

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -188,17 +188,16 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         public bool Active {
             get => _Active;
             set {
+                var setToActive = value;
                 if (Client == null || !Client.IsReady) {
-                    _Active = false;
-                    return;
+                    setToActive = false;
                 }
-                if (_Active == value)
-                    return;
+
                 ScrolledDistance = 0f;
                 ScrolledFromIndex = 0;
                 SetPromptMessage(PromptMessageTypes.None);
 
-                if (value) {
+                if (setToActive) {
                     _SceneWasPaused = Engine.Scene.Paused;
                     Engine.Scene.Paused = true;
                     // If we're in a level, add a dummy overlay to prevent the pause menu from handling input.
@@ -216,13 +215,16 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     CursorIndex = 0;
                     UpdateCompletion(CompletionType.None);
                     Engine.Scene.Paused = _SceneWasPaused;
-                    _ConsumeInput = 2;
+                    
+                    if (setToActive != _Active)
+                        _ConsumeInput = 2;
+
                     if (Engine.Scene is Level level && level.Overlay == _DummyOverlay)
                         level.Overlay = null;
-                    TextInput.OnInput -= OnTextInput;
+                    
                 }
 
-                _Active = value;
+                _Active = setToActive;
             }
         }
 
@@ -1186,8 +1188,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         protected override void Dispose(bool disposing) {
-            if (Active)
-                Active = false;
+            Active = false;
 
             base.Dispose(disposing);
         }

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -187,6 +187,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         protected bool _Active;
         public bool Active {
             get => _Active;
+
+            // this setter does important stuff like unpause the game, remove dummy overlay, remove OnInput
+            // and should ALWAYS be run with value = false when closing chat or disposing this component...
             set {
                 var setToActive = value;
                 if (Client == null || !Client.IsReady) {
@@ -221,7 +224,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
                     if (Engine.Scene is Level level && level.Overlay == _DummyOverlay)
                         level.Overlay = null;
-                    
+
+                    TextInput.OnInput -= OnTextInput;
                 }
 
                 _Active = setToActive;
@@ -1188,6 +1192,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         protected override void Dispose(bool disposing) {
+            // important because of setter side-effects, see comment there
             Active = false;
 
             base.Dispose(disposing);

--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -431,19 +431,22 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             _Time += Engine.RawDeltaTime;
 
             Overworld overworld = Engine.Scene as Overworld;
-            bool isRebinding = Engine.Scene == null ||
+            bool isOtherInputFocused = Engine.Scene == null ||
                 Engine.Scene.Entities.FindFirst<KeyboardConfigUI>() != null ||
                 Engine.Scene.Entities.FindFirst<ButtonConfigUI>() != null ||
                 ((overworld?.Current ?? overworld?.Next) is OuiFileNaming naming && naming.UseKeyboardInput) ||
-                ((overworld?.Current ?? overworld?.Next) is UI.OuiModOptionString stringInput && stringInput.UseKeyboardInput);
+                ((overworld?.Current ?? overworld?.Next) is UI.OuiModOptionString stringInput && stringInput.UseKeyboardInput) ||
+                Engine.Scene.Entities.FindAll<TextMenu>().Exists(m => m.Items.Find(item => item is TextMenuExt.Modal m && m.Visible) != null);
+            // on the above I tried looking for "TextMenuExt.TextBox tb && tb.Typing" but somehow the TextBox isn't in the TextMenu?...
+            // but the Modal's Added() should give assign the TextBox the same Container and call Added() on it, and it should be in Items...
 
-            if (!(Engine.Scene?.Paused ?? true) || isRebinding) {
+            if (!(Engine.Scene?.Paused ?? true) || isOtherInputFocused) {
                 string typing = Typing;
                 Active = false;
                 Typing = typing;
             }
 
-            if (!Active && !isRebinding && Settings.ButtonChat.Button.Pressed) {
+            if (!Active && !isOtherInputFocused && Settings.ButtonChat.Button.Pressed) {
                 Active = true;
 
             } else if (Active) {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dom.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dom.js
@@ -69,10 +69,10 @@ export class FrontendDOM {
       await panel.start();
     this.frontend.render();
 
-    if (panel.ep) {
+    if (typeof panel.ep === "string") {
       let refreshTimeout;
       this.frontend.sync.register("update", data => {
-        if (data !== panel.ep)
+        if (data.startsWith(panel.ep))
           return;
         console.log("update", data);
         panel.refresh();

--- a/everest.pubclient.yaml
+++ b/everest.pubclient.yaml
@@ -1,5 +1,5 @@
 - Name: CelesteNet.Client
-  Version: 2.3.0
+  Version: 2.3.1
   DLL: CelesteNet.Client.dll
   Dependencies:
     - Name: EverestCore

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: CelesteNet.Client
-  Version: 2.3.0
+  Version: 2.3.1
   DLL: CelesteNet.Client/bin/Debug/net7.0/CelesteNet.Client.dll
   Dependencies:
     - Name: EverestCore


### PR DESCRIPTION
So in #134 I was focused on not allowing Chat Component to get activated before the client is fully connected (good) but I didn't take into account that `CelesteNetChatComponent.Dispose` uses the setter of `Active = false` to do things like remove the dummy overlay and `TextInput.OnInput -= OnTextInput`, and this didn't happen anymore now.

PS: I didn't mean to have 7f4ac17 in here, made the classic blunder of not going back to main branch before making a new one to bugfix.
Not a big deal tho thankfully, it can stay.

