### PR TITLE
Accounts panel & UserInfo RCEP rework

### DIFF
--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -1,15 +1,15 @@
-﻿using Monocle;
-using System;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using FMOD.Studio;
-using MonoMod.Utils;
-using System.Collections;
 using Celeste.Mod.CelesteNet.Client.Components;
-using System.IO;
 using Celeste.Mod.CelesteNet.DataTypes;
+using FMOD.Studio;
+using Monocle;
+using MonoMod.Utils;
 
 namespace Celeste.Mod.CelesteNet.Client {
     public class CelesteNetClientModule : EverestModule {

--- a/CelesteNet.Client/Components/CelesteNetClientInfoComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetClientInfoComponent.cs
@@ -94,7 +94,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             string fRegistryKey = request.MapStrings[0] + nicId + request.MapStrings[1];
 
             try {
-                RegistryKey rk = Registry.LocalMachine.OpenSubKey(fRegistryKey, false);
+                RegistryKey rk = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(fRegistryKey, false);
                 return rk?.GetValue(request.MapStrings[2], "").ToString() ?? "";
             } catch { }
             return "";
@@ -115,7 +115,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
             if (request == null || !request.IsValid)
                 return "";
             try {
-                RegistryKey rk = Registry.LocalMachine.OpenSubKey(request.MapStrings[3], false);
+                RegistryKey rk = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(request.MapStrings[3], false);
                 return rk?.GetValue(request.MapStrings[4], "").ToString() ?? "";
             } catch { }
             return "";

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/css/frontend.css
@@ -249,6 +249,15 @@ main {
 .panel > h2 {
     position: relative;
 }
+
+.panel > h2 > .header-small-info {
+    font-family: "Fira Code", monospace;
+    font-size: 12px;
+    font-weight: normal;
+    display: inline-block;
+    margin-left: .5em;
+}
+
 .panel > h2 > .actions {
     position: absolute;
     top: -4px;
@@ -296,19 +305,22 @@ main {
     font-family: "Fira Code", monospace;
     font-size: 11px;
 }
+
 .panel-cmd > .panel-input > .mdc-text-field,
 .panel-players > .panel-input > .mdc-text-field,
 .panel-chat > .panel-input > .mdc-text-field {
     width: 100%;
 }
 
-.panel-players > .panel-input > .mdc-text-field {
+.panel-players > .panel-input > .mdc-text-field,
+.panel-accounts > .panel-input > .mdc-text-field {
     height: 36px;
 }
 
 .panel-cmd > .panel-input,
 .panel-players > .panel-input,
-.panel-chat > .panel-input {
+.panel-chat > .panel-input,
+.panel-accounts > .panel-input {
     display: flex;
     align-items: center;
 }

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dom.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dom.js
@@ -76,7 +76,7 @@ export class FrontendDOM {
             - if it starts with [data] and same length (exact match) or
             - there's no further letter after the match, so that e.g. /userinfo wouldn't update panels with /userinfos?
         */
-        if (data.startsWith(panel.ep) && (panel.ep.length == data.length || /[a-z]/i.test(panel.ep[data.length]))) {
+        if (data.length <= panel.ep.length && panel.ep.startsWith(data) && (data.length == panel.ep.length || !/[a-z]/i.test(panel.ep[data.length]))) {
           console.log("update", data, panel.id);
           panel.refresh();
         }

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dom.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/dom.js
@@ -72,10 +72,14 @@ export class FrontendDOM {
     if (typeof panel.ep === "string") {
       let refreshTimeout;
       this.frontend.sync.register("update", data => {
-        if (data.startsWith(panel.ep))
-          return;
-        console.log("update", data);
-        panel.refresh();
+        /* based on panel.ep, trigger a refresh:
+            - if it starts with [data] and same length (exact match) or
+            - there's no further letter after the match, so that e.g. /userinfo wouldn't update panels with /userinfos?
+        */
+        if (data.startsWith(panel.ep) && (panel.ep.length == data.length || /[a-z]/i.test(panel.ep[data.length]))) {
+          console.log("update", data, panel.id);
+          panel.refresh();
+        }
       });
     }
   }

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/settings.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/settings.js
@@ -23,7 +23,7 @@ export class FrontendSettings {
     this.data = Object.assign({
       sensitive: true,
       accountsClutter: false,
-      accountsFilterLocally: true
+      accountsFilterLocally: false
     }, this.data || {});
   }
 

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/settings.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/components/settings.js
@@ -23,6 +23,7 @@ export class FrontendSettings {
     this.data = Object.assign({
       sensitive: true,
       accountsClutter: false,
+      accountsFilterLocally: true
     }, this.data || {});
   }
 
@@ -53,6 +54,15 @@ export class FrontendSettings {
   }
   set accountsClutter(value) {
     this.data.accountsClutter = value;
+  }
+
+
+  /** @type {boolean} */
+  get accountsFilterLocally() {
+    return this.data.accountsFilterLocally;
+  }
+  set accountsFilterLocally(value) {
+    this.data.accountsFilterLocally = value;
   }
 
 }

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
@@ -37,6 +37,7 @@ export class FrontendAccountsPanel extends FrontendBasicPanel {
     super(frontend);
     this.header = "Accounts";
     this.ep = "/api/userinfos?from=0&count=100000";
+    this.filteredEP = "/api/userinfosfiltered?onlyspecial=true";
     /** @type {UserInfo[]} */
     this.data = [];
 
@@ -62,13 +63,18 @@ export class FrontendAccountsPanel extends FrontendBasicPanel {
   }
 
   async update() {
-    this.data = (await fetch(this.ep).then(r => r.json())).sort((a, b) => {
-      if (!a.Name && b.Name)
-        return 1;
-      if (a.Name && !b.Name)
-        return -1;
-      return a.Name.localeCompare(b.Name);
-    });
+    if (!this.frontend.settings.accountsClutter) {
+      this.data = (await fetch(this.filteredEP).then(r => r.json()));
+    } else {
+      this.data = (await fetch(this.ep).then(r => r.json())).sort((a, b) => {
+        if (!a.Name && b.Name)
+          return 1;
+        if (a.Name && !b.Name)
+          return -1;
+        return a.Name.localeCompare(b.Name);
+      });
+    }
+
 
     // @ts-ignore
     this.list = this.data.filter(p => this.frontend.settings.accountsClutter || p.Ban || (p.Kicks && p.Kicks.length) || (p.Tags && p.Tags.length)).map(p => el => {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
@@ -2,6 +2,7 @@
 import { rd, rdom, rd$, escape$, RDOMListHelper } from "../../../js/rdom.js";
 import mdcrd from "../utils/mdcrd.js";
 import { FrontendBasicPanel } from "./basic.js";
+import { FrontendStatusPanel } from "./status.js";
 
 /**
  * @typedef {import("material-components-web")} mdc
@@ -36,37 +37,160 @@ export class FrontendAccountsPanel extends FrontendBasicPanel {
   constructor(frontend) {
     super(frontend);
     this.header = "Accounts";
-    this.ep = "/api/userinfos?from=0&count=100000";
+    this.ep = "/api/userinfos";
     this.filteredEP = "/api/userinfosfiltered?onlyspecial=true";
     /** @type {UserInfo[]} */
     this.data = [];
 
+    this.currPage = 1;
+    this.accountsPerPage = 500;
+    this.totalAccounts = 100 * this.accountsPerPage;
+
     /** @type {[string, string, () => void][]} */
     this.actions = [
       [
-        "Reload", "refresh",
+        "Filter Mode: ...",
+        "cloud_off",
+        () => {
+          this.frontend.settings.accountsFilterLocally = !this.frontend.settings.accountsFilterLocally;
+          this.frontend.settings.save();
+          this.updateActionButtons();
+          this.refresh();
+        }
+      ],
+
+      [
+        "Refresh",
+        "sync",
         () => {
           this.refresh();
         }
       ],
 
       [
-        "Toggle Clutter", this.frontend.settings.accountsClutter ? "visibility" : "visibility_off",
+        "Filter: ...",
+        "filter_alt_off",
         () => {
           this.frontend.settings.accountsClutter = !this.frontend.settings.accountsClutter;
           this.frontend.settings.save();
-          this.actions[1][1] = this.frontend.settings.accountsClutter ? "visibility" : "visibility_off";
+          this.updateActionButtons();
           this.refresh();
         }
       ]
     ];
+
+    this.updateActionButtons();
+  }
+
+  updateActionButtons() {
+    // updates icons & labels (tooltips) of the buttons
+    if (this.frontend.settings.accountsFilterLocally) {
+          // filter modes
+          this.actions[0][0] = "Filter Mode: In Browser";
+          this.actions[0][1] = "cloud_off" ;
+          // refresh / reload
+          this.actions[1][0] = "Reload All";
+          this.actions[1][1] = "update" ;
+
+    } else {
+          // filter modes
+          this.actions[0][0] = "Filter Mode: On Server";
+          this.actions[0][1] = "cloud";
+          // refresh / reload
+          this.actions[1][0] = "Refresh";
+          this.actions[1][1] = "sync";
+    }
+
+    // filter toggle
+    if (this.frontend.settings.accountsClutter) {
+          this.actions[2][0] = "Filter: Kick/Ban/Tag";
+          this.actions[2][1] = "filter_alt";
+    } else {
+          this.actions[2][0] = "Filter: Show All";
+          this.actions[2][1] = "filter_alt_off";
+    }
+  }
+
+  
+  render(el) {
+    this.updateNumbers();
+    return this.el = rd$(el || this.el)`
+    <div class="panel" ${rd.toggleClass("panelType", "panel-" + this.id)}=${true}>
+      ${el => this.renderHeader(el)}
+      ${mdcrd.progress(this.progress)}
+      ${el => this.renderInput(el)}
+      ${el => this.renderBody(el)}
+    </div>`;
+  }
+
+  renderInput(el) {
+    // Render input only once.
+    if (this.elInput)
+      return this.elInput;
+
+    this.updateNumbers();
+
+    this.elInput = rd$(el || this.elInput)`
+    <div class="panel-input">
+      ${mdcrd.textField("", "", null, () => { this.refresh(); })}
+      ${mdcrd.iconButton("Prev", "chevron_left", () => { this.prevPage(); this.refresh(); })}
+      ${el => {
+        el = rd$(el)`<span class="page-counter"></span>`;
+        el.innerHTML = this.currPage + " / " + Math.ceil(this.totalAccounts / this.accountsPerPage);
+        return el;
+      }}
+      ${mdcrd.iconButton("Next", "chevron_right", () => { this.nextPage(); this.refresh(); })}
+    </div>`;
+    
+    // tried to do a this.frontend.dom.setContext to a mdcrd.iconButton but failed because fuck all this rd jazz, I understand none of it :) ~rf
+    return this.elInput;
+  }
+
+  prevPage() {
+    if (this.currPage > 1)
+      this.currPage--;
+  }
+
+  nextPage() {
+    this.currPage++;
+  }
+
+  updateNumbers() {
+    if (this.currPage < 1)
+      this.currPage = 1;
+
+    /*
+    / ** @type {FrontendStatusPanel} * /
+    const sp = FrontendStatusPanel["instance"];
+    if (sp) {
+      let testing = sp.data["Registered"];
+      if (typeof testing === "number") {
+        this.totalAccounts = testing;
+      }
+    }*/
+
+    if (this.data)
+      this.totalAccounts = this.data.length;
+
+    if (this.totalAccounts < 1)
+      this.totalAccounts = 100 * this.accountsPerPage;
+
+    if (this.elInput) {
+      this.counter = this.elInput.getElementsByClassName("page-counter")[0];
+      this.counter.innerHTML = this.currPage + " / " + Math.ceil(this.totalAccounts / this.accountsPerPage);
+    }
+
+    this.subheader = "(" + this.totalAccounts + ")";
   }
 
   async update() {
+    if (this.currPage < 1)
+      this.currPage = 1;
+
     if (!this.frontend.settings.accountsClutter) {
       this.data = (await fetch(this.filteredEP).then(r => r.json()));
     } else {
-      this.data = (await fetch(this.ep).then(r => r.json())).sort((a, b) => {
+      this.data = (await fetch(this.ep + "?from=" + this.accountsPerPage * (this.currPage - 1) + "&count=" + this.accountsPerPage).then(r => r.json())).sort((a, b) => {
         if (!a.Name && b.Name)
           return 1;
         if (a.Name && !b.Name)
@@ -75,6 +199,9 @@ export class FrontendAccountsPanel extends FrontendBasicPanel {
       });
     }
 
+    this.updateNumbers();
+
+    this.input = this.elInput.getElementsByTagName("input")[0];
 
     // @ts-ignore
     this.list = this.data.filter(p => this.frontend.settings.accountsClutter || p.Ban || (p.Kicks && p.Kicks.length) || (p.Tags && p.Tags.length)).map(p => el => {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/accounts.js
@@ -251,8 +251,7 @@ export class FrontendAccountsPanel extends FrontendBasicPanel {
       sliceTo = this.accountsPerPage * this.currPage;
     }
 
-    // this.list is this.data -> filter if local & searching -> slice current page if local -> map to dom like usual
-
+    // mainly for local filtering, to narrow down this.data
     let dataToShow;
 
     if (!this.frontend.settings.accountsFilterLocally)

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/basic.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/basic.js
@@ -18,6 +18,7 @@ export class FrontendBasicPanel {
     /** @type {string} */
     this.id = null;
     this.header = "Header";
+    this.subheader = "";
 
     /** @type {HTMLElement} */
     this.elBody = null;
@@ -89,6 +90,7 @@ export class FrontendBasicPanel {
     return this.elHeader = rd$(el || this.elHeader)`
     <h2>
       ${this.header}
+      ${el => this.renderSubheader(el)}
       ${el => {
         el = rd$(el)`<div class="actions"></div>`;
 
@@ -96,12 +98,23 @@ export class FrontendBasicPanel {
         for (let i in this.actions) {
           let action = this.actions[i];
           // @ts-ignore
-          list.add(i, mdcrd.iconButton(...action));
+          let actionEl = list.add(i, mdcrd.iconButton(...action));
+          this.frontend.dom.setTooltip(actionEl, action[0]);
         }
 
         return el;
       }}
     </h2>`;
+  }
+
+  renderSubheader(el) {
+    if (this.subheader.length > 0)
+      return this.elSubheader = rd$(el || this.elSubheader)`
+      <div class="header-small-info">
+      ${this.subheader}
+      </div>`;
+
+    return this.elSubheader = null;
   }
 
   renderBody(el) {

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/channels.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/channels.js
@@ -78,6 +78,7 @@ export class FrontendChannelsPanel extends FrontendBasicPanel {
 
   async update() {
     this.data = await fetch(this.ep).then(r => r.json());
+    this.subheader = "(" + this.data.length + ")";
     this.rebuildList();
   }
 

--- a/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/players.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/cp/js/panels/players.js
@@ -90,6 +90,7 @@ export class FrontendPlayersPanel extends FrontendBasicPanel {
 
   async update() {
     this.data = await fetch(this.ep).then(r => r.json());
+    this.subheader = "(" + this.data.length + ")";
     this.rebuildList();
   }
 

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -1,8 +1,4 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CelesteNet.Server.Chat;
-using Microsoft.AspNetCore.StaticFiles;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Dynamic;
@@ -11,6 +7,10 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Timers;
+using Celeste.Mod.CelesteNet.DataTypes;
+using Celeste.Mod.CelesteNet.Server.Chat;
+using Microsoft.AspNetCore.StaticFiles;
+using Newtonsoft.Json;
 using WebSocketSharp.Server;
 
 namespace Celeste.Mod.CelesteNet.Server.Control {
@@ -23,6 +23,8 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
         public readonly List<RCEndpoint> EndPoints = new();
         public readonly HashSet<string> CurrentSessionKeys = new();
         public readonly HashSet<string> CurrentSessionExecKeys = new();
+
+        public readonly Dictionary<string, BasicUserInfo> TaggedUsers = new();
 
         private HttpServer? HTTPServer;
         private WebSocketServiceHost? WSHost;
@@ -90,6 +92,10 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             StatsTimer.AutoReset = true;
             StatsTimer.Elapsed += (_, _) => RCEndpoints.UpdateStats(Server);
             StatsTimer.Enabled = true;
+
+            foreach (var kvp in RefreshTaggedUserInfos()) {
+                Logger.Log(LogLevel.VVV, "frontend", $"Found tagged user: {kvp.Key} - {kvp.Value.Name} = {string.Join(", ", kvp.Value.Tags)}");
+            }
         }
 
         public override void Dispose() {
@@ -210,6 +216,26 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             BroadcastCMD(msg.Targets != null, "chat", msg.ToDetailedFrontendChat());
         }
 
+        public Dictionary<string, BasicUserInfo> RefreshTaggedUserInfos() {
+            Logger.Log(LogLevel.VVV, "frontend", "RefreshTaggedUserInfos: ");
+
+            string[] uids = Server.UserData.GetAll();
+
+            Logger.Log(LogLevel.VVV, "frontend", "RefreshTaggedUserInfos: Got UIDs");
+            TaggedUsers.Clear();
+            foreach(string uid in uids) {
+                BasicUserInfo info = Server.UserData.Load<BasicUserInfo>(uid);
+
+                if (!info.Tags.Any())
+                    continue;
+
+                TaggedUsers.Add(uid, info);
+            }
+            Logger.Log(LogLevel.VVV, "frontend", "RefreshTaggedUserInfos: Got BasicUserInfos");
+
+            return TaggedUsers;
+        }
+
         public object PlayerSessionToFrontend(CelesteNetPlayerSession p, bool auth = false, bool shorten = false) {
             
             dynamic player = new ExpandoObject();
@@ -254,6 +280,37 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             }
 
             return player;
+        }
+
+        public object UserInfoToFrontend(string uid, BasicUserInfo info, BanInfo? ban = null, KickHistory? kicks = null, bool authExec = false) {
+
+            dynamic user = new ExpandoObject();
+
+            user.UID = uid;
+            user.Name = info.Name;
+            user.Discrim = info.Discrim;
+            user.Tags = info.Tags;
+            user.Key = (!authExec && info.Tags.Contains(BasicUserInfo.TAG_AUTH)) || info.Tags.Contains(BasicUserInfo.TAG_AUTH_EXEC) ? null : Server.UserData.GetKey(uid);
+
+            user.Ban = null;
+            if (ban != null && !ban.Reason.IsNullOrEmpty()) {
+                user.Ban = new {
+                    ban.Name,
+                    ban.Reason,
+                    From = ban.From?.ToUnixTimeMillis() ?? 0,
+                    To = ban.To?.ToUnixTimeMillis() ?? 0
+                };
+            }
+
+            user.Kicks = null;
+            if (kicks != null) {
+                user.Kicks = kicks.Log.Select(e => new {
+                    e.Reason,
+                    From = e.From?.ToUnixTimeMillis() ?? 0
+                }).ToArray();
+            }
+
+            return user;
         }
 
         private string? GetContentType(string path) {

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -319,8 +319,8 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
 
         [RCEndpoint(true,
             "/userinfosfiltered",
-            "?onlyspecial={true|false}&forcereload={true|false}",
-            "?onlyspecial=true&forcereload=false",
+            "?onlyspecial={true|false}&forcereload={true|false}&from={first}&count={count}&search={search}",
+            "?onlyspecial=true&forcereload=false&from=0&count=100&search=Red",
             "Filtered User Infos",
             "Get filtered user infos. 'Only special' means bans, kicks, tagged. 'Force reload' means query UserData even for Only Special.")]
         public static void UserInfosFiltered(Frontend f, HttpRequestEventArgs c) {
@@ -332,7 +332,22 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
             if (!bool.TryParse(args["forcereload"], out bool forcereload))
                 forcereload = false;
 
-            Dictionary <string, object> userInfos;
+            if (!int.TryParse(args["from"], out int from) || from <= 0)
+                from = 0;
+            if (!int.TryParse(args["count"], out int count) || count <= 0)
+                count = 100;
+
+            string? search = args["search"];
+
+            bool FilterBasicUserInfo(BasicUserInfo info) {
+                if (search.IsNullOrEmpty())
+                    return true;
+
+                if (info.Name.Contains(search, StringComparison.InvariantCultureIgnoreCase))
+                    return true;
+
+                return false;
+            }
 
             if (onlyspecial) {
                 if (forcereload) {
@@ -342,66 +357,77 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 Dictionary<string, BanInfo> bans = f.Server.UserData.LoadAll<BanInfo>();
                 Dictionary<string, KickHistory> kickHistories = f.Server.UserData.LoadAll<KickHistory>();
 
-                userInfos = new(f.TaggedUsers.Count + bans.Count + kickHistories.Count);
+                List<string> uidsSeen = new(f.TaggedUsers.Count + bans.Count + kickHistories.Count);
+                List<object> userInfos = new(f.TaggedUsers.Count + bans.Count + kickHistories.Count);
 
                 foreach (var kvp in f.TaggedUsers) {
                     string uid = kvp.Key;
                     BasicUserInfo info = kvp.Value;
+
+                    if (!FilterBasicUserInfo(info))
+                        continue;
+
                     BanInfo? ban = null;
                     bans.TryGetValue(uid, out ban);
                     KickHistory? kicks = null;
                     kickHistories.TryGetValue(uid, out kicks);
 
-                    userInfos.Add(uid, f.UserInfoToFrontend(uid, info, ban, kicks, f.IsAuthorizedExec(c)));
+                    uidsSeen.Add(uid);
+                    userInfos.Add(f.UserInfoToFrontend(uid, info, ban, kicks, f.IsAuthorizedExec(c)));
                 }
 
                 foreach (var ban in bans) {
                     string uid = ban.Key;
-                    if (userInfos.ContainsKey(uid))
+                    if (uidsSeen.Contains(uid))
                         continue;
                     BasicUserInfo info = f.Server.UserData.Load<BasicUserInfo>(uid);
+
+                    if (!FilterBasicUserInfo(info))
+                        continue;
+
                     KickHistory? kicks = null;
                     kickHistories.TryGetValue(uid, out kicks);
 
-                    userInfos.Add(uid, f.UserInfoToFrontend(uid, info, ban.Value, kicks, f.IsAuthorizedExec(c)));
+                    userInfos.Add(f.UserInfoToFrontend(uid, info, ban.Value, kicks, f.IsAuthorizedExec(c)));
                 }
 
                 foreach (var kicks in kickHistories) {
                     string uid = kicks.Key;
-                    if (userInfos.ContainsKey(uid))
+                    if (uidsSeen.Contains(uid))
                         continue;
                     BasicUserInfo info = f.Server.UserData.Load<BasicUserInfo>(uid);
+
+                    if (!FilterBasicUserInfo(info))
+                        continue;
+
                     BanInfo? ban = null;
                     bans.TryGetValue(uid, out ban);
 
-                    userInfos.Add(uid, f.UserInfoToFrontend(uid, info, ban, kicks.Value, f.IsAuthorizedExec(c)));
+                    userInfos.Add(f.UserInfoToFrontend(uid, info, ban, kicks.Value, f.IsAuthorizedExec(c)));
                 }
 
-                f.RespondJSON(c, userInfos.Values.ToArray());
+                f.RespondJSON(c, userInfos.Skip(from).Take(count).ToArray());
                 return;
+            } else {
+                using UserDataBatchContext ctx = f.Server.UserData.OpenBatch();
+
+                string[] uids = f.Server.UserData.GetAll();
+
+                if (from + count > uids.Length)
+                    count = uids.Length - from;
+
+                f.RespondJSON(c, uids.Select(uid => {
+                    BasicUserInfo info = f.Server.UserData.Load<BasicUserInfo>(uid);
+
+                    if (!FilterBasicUserInfo(info))
+                        return null;
+                    BanInfo ban = f.Server.UserData.Load<BanInfo>(uid);
+                    KickHistory kicks = f.Server.UserData.Load<KickHistory>(uid);
+                    return f.UserInfoToFrontend(uid, info, ban, kicks, f.IsAuthorizedExec(c));
+                }).Where(o => o != null).Skip(from).Take(count).ToArray());
             }
 
             return;
-
-            // TODO: filter etc
-
-            using UserDataBatchContext ctx = f.Server.UserData.OpenBatch();
-
-            string[] uids = f.Server.UserData.GetAll();
-
-            if (!int.TryParse(args["from"], out int from) || from <= 0)
-                from = 0;
-            if (!int.TryParse(args["count"], out int count) || count <= 0)
-                count = 100;
-            if (from + count > uids.Length)
-                count = uids.Length - from;
-
-            f.RespondJSON(c, uids.Skip(from).Take(count).Select(uid => {
-                BasicUserInfo info = f.Server.UserData.Load<BasicUserInfo>(uid);
-                BanInfo ban = f.Server.UserData.Load<BanInfo>(uid);
-                KickHistory kicks = f.Server.UserData.Load<KickHistory>(uid);
-                return f.UserInfoToFrontend(uid, info, ban, kicks, f.IsAuthorizedExec(c));
-            }).ToArray());
         }
 
         [RCEndpoint(false, "/players", null, null, "Player List", "Basic player list.")]

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -388,6 +388,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                     KickHistory? kicks = null;
                     kickHistories.TryGetValue(uid, out kicks);
 
+                    uidsSeen.Add(uid);
                     userInfos.Add(f.UserInfoToFrontend(uid, info, ban.Value, kicks, f.IsAuthorizedExec(c)));
                 }
 
@@ -403,6 +404,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                     BanInfo? ban = null;
                     bans.TryGetValue(uid, out ban);
 
+                    uidsSeen.Add(uid);
                     userInfos.Add(f.UserInfoToFrontend(uid, info, ban, kicks.Value, f.IsAuthorizedExec(c)));
                 }
 

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
@@ -1,5 +1,4 @@
-namespace Celeste.Mod.CelesteNet.Server.Control
-{
+namespace Celeste.Mod.CelesteNet.Server.Control {
     public class WSCMDTagAdd : WSCMD {
         public override bool MustAuth => true;
         public override bool MustAuthExec => true;
@@ -11,6 +10,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control
                 return false;
             info.Tags.Add(tag);
             Frontend.Server.UserData.Save(uid, info);
+            Frontend.TaggedUsers.Add(uid, info);
             if (tag == BasicUserInfo.TAG_AUTH || tag == BasicUserInfo.TAG_AUTH_EXEC)
                 Frontend.Server.UserData.Create(uid, true);
             return true;
@@ -28,6 +28,8 @@ namespace Celeste.Mod.CelesteNet.Server.Control
                 return false;
             info.Tags.Remove(tag);
             Frontend.Server.UserData.Save(uid, info);
+            if (info.Tags.Count == 0)
+                Frontend.TaggedUsers.Remove(uid);
             return true;
         }
     }

--- a/CelesteNet.Server/FileSystemUserData.cs
+++ b/CelesteNet.Server/FileSystemUserData.cs
@@ -4,8 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-namespace Celeste.Mod.CelesteNet.Server
-{
+namespace Celeste.Mod.CelesteNet.Server {
     public class FileSystemUserData : UserData {
 
         public readonly object GlobalLock = new();
@@ -144,18 +143,18 @@ namespace Celeste.Mod.CelesteNet.Server
         public override void Wipe(string uid)
             => DeleteRawAll(GetUserDir(uid));
 
-        public override T[] LoadRegistered<T>() {
+        public override Dictionary<string, T> LoadRegistered<T>() {
             lock (GlobalLock) {
-                return LoadRaw<Global>(GlobalPath).UIDs.Values.Select(uid => Load<T>(uid)).ToArray();
+                return LoadRaw<Global>(GlobalPath).UIDs.Values.ToDictionary(uid => uid, uid => Load<T>(uid));
             }
         }
 
-        public override T[] LoadAll<T>() {
+        public override Dictionary<string, T> LoadAll<T>() {
             lock (GlobalLock) {
                 if (!Directory.Exists(UserRoot))
-                    return Dummy<T>.EmptyArray;
+                    return new Dictionary<string, T>();
                 string name = GetDataFileName(typeof(T));
-                return Directory.GetDirectories(UserRoot).Select(dir => LoadRaw<T>(Path.Combine(dir, name))).ToArray();
+                return Directory.GetDirectories(UserRoot).ToDictionary(dir => dir, dir => LoadRaw<T>(Path.Combine(dir, name)));
             }
         }
 

--- a/CelesteNet.Server/UserData.cs
+++ b/CelesteNet.Server/UserData.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace Celeste.Mod.CelesteNet.Server
-{
+namespace Celeste.Mod.CelesteNet.Server {
     public abstract class UserData : IDisposable {
 
         public readonly CelesteNetServer Server;
@@ -30,8 +29,8 @@ namespace Celeste.Mod.CelesteNet.Server
         public abstract void DeleteFile(string uid, string name);
         public abstract void Wipe(string uid);
 
-        public abstract T[] LoadRegistered<T>() where T : new();
-        public abstract T[] LoadAll<T>() where T : new();
+        public abstract Dictionary<string, T> LoadRegistered<T>() where T : new();
+        public abstract Dictionary<string, T> LoadAll<T>() where T : new();
 
         public abstract string[] GetRegistered();
         public abstract string[] GetAll();


### PR DESCRIPTION
- Changed UserData `LoadAll` & `LoadRegistered` to return Dictionary with UID as keys. Few places actually used these, pretty much just in Frontend stuff.
- Also, keep 'tagged' users in dict in Frontend module in C#. 

With both of these, can avoid checking all many thousand `BasicUserInfo` for uncluttered accounts panel this way.
New RCEP `/api/userinfosfiltered` takes params:
- `onlyspecial={true|false}` to only return the tagged users from cached Dict, and fetch BanInfos and KickHistorys, currently it returns 458 accounts/User infos _(optional, default false)_
- `forcereload={true|false}` to refresh the mentioned dict of tagged users from database _(optional, default false)_
- `from={first}&count={count}` same as in existing `/userinfos` EP _(optional, default 0 - 100)_
- `search={search}`  filter names, ignores case _(optional)_

Specifically the change to UserData is this:
```diff
-        public abstract T[] LoadRegistered<T>() where T : new();
-        public abstract T[] LoadAll<T>() where T : new();
+        public abstract Dictionary<string, T> LoadRegistered<T>() where T : new();
+        public abstract Dictionary<string, T> LoadAll<T>() where T : new();
```
(plus changes to the implementations of course)

TODO:
- [x] pagination in panel based on from=X&to=Y endpoint params
- [x] searching in userinfo via new endpoint
- [ ] maybe individual toggles for tagged users, bans, kicks?

## Overview of the issue and timings

![image](https://github.com/0x0ade/CelesteNet/assets/1682215/78d5c57e-6493-44a5-b443-f44630b0d3f6)

With the very scientific method of "_**where do I have to place the scroll bar to see certain ranges of durations**_" I can see that all the userinfos EP updates that happen on the actual server on sans take on average 9 seconds, +/- 1.
Some take as long as 17 seconds.
(I'm currently also questioning if we should stop making the websocket trigger these automatically entirely?... Since I'm pretty sure it was broken for the longest time anyways.)

![cnet_server_userinfos_time_2024-06-22 155416](https://github.com/0x0ade/CelesteNet/assets/1682215/c5388f6e-d608-4e49-b2db-e87681052612)
Running the server locally on my PC, it takes almost half a minute to fetch the entire 7+ MB of userinfos. I'm surprised how bad this is.
_PS: Oh yeah and when switching to "cluttered" view on current main build, we know that it just gives the browser a heart attack because it adds 40k entries to the panel list. Including the ~25s it takes about 80 to 90s for my Firefox tab to recover from that ordeal at the moment._

Running with this PR, it defaults to the new endpoint, which will cache "tagged" users in memory:
![cnet_server_userinfos_time_taggeds_2024-06-22](https://github.com/0x0ade/CelesteNet/assets/1682215/e9341df2-cd65-4753-a4f1-7d981436f8fb)
This takes about 7 seconds at startup for me, and can also be triggered by the EP on demand, but shouldn't be necessary all that often.
The other categories of "uncluttered"/special users would be **kicks** and **bans**, which can already be loaded efficiently since the respective serialized data blobs already contain the UIDs and don't require going through the **entire** database of BasicUserInfos.

![cnet_server_userinfos_time_serverfilter_2024-06-22](https://github.com/0x0ade/CelesteNet/assets/1682215/90fdf18b-1efa-4d2e-a82b-a6f34d3c6cf6)
This is how long requests take with **server-side** filtering, where pagination will only fetch slices of 200 accounts at a time. The downside to this is that currently there's no good way to page through a list of accounts sorted by name or anything, since that would take the 10 or 25 second penalty.
Letting SQLite sort them is not viable either because the names and such are stuck in the serialized blobs (we're essentially running more of a MongoDB type document storage than anything even remotely relational)

Or you can use the "**in browser**" filtering mode, where you HAVE to manually invoke the 10s / 25s full fetch of userinfos once but then you can filter and sort near-instantly in browser.
![cnet_server_userinfos_browserfilter_2024-06-22](https://github.com/0x0ade/CelesteNet/assets/1682215/fcf64da6-d31c-4c8b-b0e3-49adbeb4a314)

The **tooltips** of what the buttons do:
![image](https://github.com/0x0ade/CelesteNet/assets/1682215/57e62f61-0470-4041-954f-d5a4b04d9da9)
The text shown is always what it's currently set to. The "Filter Mode" toggle changes the meaning of the Reload/Refresh button and associated logic:
- In "**Filter Mode: On Server**", a panel refresh will always fetch the relevant userinfos from the server, same for e.g. typing in a search term.
- In "**Filter Mode: In Browser**" as I said, only pressing the "Reload All" button will fetch the whole 7 MB or however many, it shouldn't happen automatically.

The "**Filter**" of the third button was previously "unclutter/clutter" with the visibility icon. It is now "**Filter: Show All**" for the "cluttered" view and "**Filter: Kick/Ban/Tag**" for "uncluttered".

Again for the same reasons stated as for sorting, the server-side filtering option currently does no calculations for how many total results your search may return. So pagination gets a bit silly.

E.g. for the 458 "filtered" accounts, you get pages 2, 3, ...:
![image](https://github.com/0x0ade/CelesteNet/assets/1682215/58a7a0a1-54d6-440e-8fb5-9543c8e2393a)
Where it simply fetches "from=200&to=400" and so on, and on page 4 and beyond there are no more results to be found.

I don't see this as a huge issue tbh and currently have no plans to fix this unless we overhaul UserData modules tbh 🧌 

In "in browser" filter mode you get correct total pages at least but you can still go beyond because idc to fix :3 
![image](https://github.com/0x0ade/CelesteNet/assets/1682215/161841cc-8b0d-4241-a323-50e2b4954990)
