### PR TITLE
Allow users to connect with an "illegal" LastChannelUserInfo

### DIFF
--- a/CelesteNet.Server.FrontendModule/Content/frontend/main/index.js
+++ b/CelesteNet.Server.FrontendModule/Content/frontend/main/index.js
@@ -133,7 +133,12 @@ function renderUser() {
 			<a id="button-revokekey" class="button" onclick=${() => revokeKey()}>
 				<span class="button-icon"></span>
 				<span class="button-text">Revoke Key</span>
+			</a><br>
+			<a id="button-resetuserdata" class="button" onclick=${() => resetUserData()}>
+				<span class="button-icon"></span>
+				<span class="button-text">Reset Extra User Data</span>
 			</a>
+
 		</p>`);
 
 		list.end();
@@ -146,6 +151,10 @@ function deauth() {
 
 function revokeKey() {
 	fetch(`${apiroot}/revokekey?t=${Date.now()}`).then(() => window.location.reload());
+}
+
+function resetUserData() {
+	fetch(`${apiroot}/resetuserdata?t=${Date.now()}`).then(() => window.location.reload());
 }
 
 function dialog(content) {

--- a/CelesteNet.Server.FrontendModule/Frontend.cs
+++ b/CelesteNet.Server.FrontendModule/Frontend.cs
@@ -1,8 +1,4 @@
-﻿using Celeste.Mod.CelesteNet.DataTypes;
-using Celeste.Mod.CelesteNet.Server.Chat;
-using Microsoft.AspNetCore.StaticFiles;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Dynamic;
@@ -11,6 +7,10 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Timers;
+using Celeste.Mod.CelesteNet.DataTypes;
+using Celeste.Mod.CelesteNet.Server.Chat;
+using Microsoft.AspNetCore.StaticFiles;
+using Newtonsoft.Json;
 using WebSocketSharp.Server;
 
 namespace Celeste.Mod.CelesteNet.Server.Control {

--- a/CelesteNet.Server/FileSystemUserData.cs
+++ b/CelesteNet.Server/FileSystemUserData.cs
@@ -4,8 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-namespace Celeste.Mod.CelesteNet.Server
-{
+namespace Celeste.Mod.CelesteNet.Server {
     public class FileSystemUserData : UserData {
 
         public readonly object GlobalLock = new();

--- a/CelesteNet.Server/UserData.cs
+++ b/CelesteNet.Server/UserData.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace Celeste.Mod.CelesteNet.Server
-{
+namespace Celeste.Mod.CelesteNet.Server {
     public abstract class UserData : IDisposable {
 
         public readonly CelesteNetServer Server;


### PR DESCRIPTION
It has come to my attention that I goofed something up and it fully prevents some unfortunate few from connecting to CelesteNet.

The goof-up is here:
https://github.com/0x0ade/CelesteNet/commit/1f902cf66aa1a1709d7c2ef09f3594c718ad0b0a
(part of https://github.com/0x0ade/CelesteNet/pull/109 which was merged for and deployed on the server with/on [server-2024-04-20](https://github.com/0x0ade/CelesteNet/milestone/5))

The `Exception` this throws (which really should be a custom one) is meant to be handled by the `/channel` or `/join` chat commands as feedback to the user
https://github.com/0x0ade/CelesteNet/blob/218210e8b6ba273c2b46b4179395b6dbe005da66/CelesteNet.Server.ChatModule/CMDs/CmdChannel.cs#L103-L111

~~But at some point (https://github.com/0x0ade/CelesteNet/commit/a421987ae03ef6e542c81a23dcebc064fcdbc7d0) I introduced the `Channels.SessionStartupMove(...)` function to replace hooking `Server.OnSessionStart` as a way to do the initial move of a new session to the channel they were previously in.~~
(`SessionStartupMove` was introduced to make smarter decisions on whether all player states should be re-sent, which was sometimes done multiple times when establishing new sessions)

But since `SessionStartupMove` never catches the bare `Exception`s that get thrown by `Channels.Move`, this means users simply get disconnected if this move fails.

Edit: Actually both with `SessionStartupMove` and before that with `Server.OnSessionStart` it would've ended the session because of the Exception in either case.

This was brought to my attention by some unfortunate users who were in the channel `!`. It used to already be impossible to get into `NamePrivate = "!<private>"` as a channel, but in that commit I linked at the top here I additionally made it impossible to join `PrefixPrivate = "!"`.

(If nothing had changed about what you can and can't join, this issue wouldn't have come up, and it only affects people who had been in channel `!` when the server got updated!)

The fix for now is to catch the `Exception` in `SessionStartupMove` and remove the `LastChannelUserInfo` that caused the "illegal" move and continue with moving the session to the default channel "main".

I also added a new endpoint `/api/resetuserdata` that allows deleting all the "extra" info stored about a user:
```
UserData.Delete<LastChannelUserInfo>(uid);
UserData.Delete<ChatModule.UserChatSettings>(uid);
UserData.Delete<Chat.Cmd.TPSettings>(uid);
```
currently these are the ones getting removed, i.e. the stored last channel, the auto channel chat toggle, whisper toggle and the tpon/tpoff toggle.

This is meant for debugging in case resetting these is somehow still necessary for someone at some point. It has a button below the Revoke Key button, to do this to yourself.
![image](https://github.com/0x0ade/CelesteNet/assets/1682215/a5780b02-db66-438d-84f3-d7eb20ab16c3)

:)