### PR TITLE
Command parser CmdEnv.Text not stripping non-lowercase commands where it should

### DIFF
--- a/CelesteNet.Server.ChatModule/CMDs/CommandsContext.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CommandsContext.cs
@@ -23,9 +23,9 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
                 // TODO: We have a lot of things in the server that throw Exceptions to indicate we can't properly run,
                 // we should perhaps convert those to Trace.Assert?
                 Trace.Assert(cmd is not null, $"Cannot create instance of CMD {type.FullName}");
-                Logger.Log(LogLevel.VVV, "chatcmds", $"Found command: {cmd!.ID.ToLowerInvariant()} ({type.FullName}, {cmd.Completion})");
+                Logger.Log(LogLevel.VVV, "chatcmds", $"Found command: {cmd!.ID} ({type.FullName}, {cmd.Completion})");
                 All.Add(cmd);
-                ByID[cmd.ID.ToLowerInvariant()] = cmd;
+                ByID[cmd.ID] = cmd;
                 ByType[type] = cmd;
             }
             DataAll.List = new CommandInfo[All.Count];
@@ -42,14 +42,14 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
                     ByType.TryGetValue(cmdBase, out aliasTo);
 
                 if (aliasTo != null)
-                    Logger.Log(LogLevel.VVV, "chatcmds", $"Command: {cmd.ID.ToLowerInvariant()} is {(cmd.InternalAliasing ? "internal alias" : "alias")} of {aliasTo.ID.ToLowerInvariant()}");
+                    Logger.Log(LogLevel.VVV, "chatcmds", $"Command: {cmd.ID} is {(cmd.InternalAliasing ? "internal alias" : "alias")} of {aliasTo.ID}");
 
                 DataAll.List[i++] = new CommandInfo() {
                     ID = cmd.ID,
                     Auth = cmd.MustAuth,
                     AuthExec = cmd.MustAuthExec,
                     FirstArg = cmd.Completion,
-                    AliasTo = cmd.InternalAliasing ? "" : aliasTo?.ID.ToLowerInvariant() ?? ""
+                    AliasTo = cmd.InternalAliasing ? "" : aliasTo?.ID ?? ""
                 };
             }
 
@@ -238,7 +238,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
         public string FullText => Msg.Text;
         public string Text {
             get {
-                if (Cmd == null || !Msg.Text.StartsWith(Cmd.InvokeString)) {
+                if (Cmd == null || !Msg.Text.ToLowerInvariant().StartsWith(Cmd.InvokeString)) {
                     return Msg.Text;
                 } else {
                     return Msg.Text.Substring(Cmd.InvokeString.Length);


### PR DESCRIPTION
CmdEnv.Text property implementation had a bug related to lettercasing where it would not recognise non-lowercase command invocations as something to strip from Msg.Text as it should've.

This bug was introduced during #127 where apparently in its two commits I first removed CmdEnv.Text (https://github.com/0x0ade/CelesteNet/commit/7d0544108b89f4ecb18808c0302e289a29fa3168) and then reintroduced a subtly broken version of it (https://github.com/0x0ade/CelesteNet/commit/2d8d7aeb0151b9178a9b135375a1fb837778e07f) :3

While adding one important call to `.ToLowerInvariant()`, I have also removed 5 superfluous ones that were applied to ChatCmd.ID even though that and by extension ChatCmd.InvokeString are already guaranteed to be lowercase per their definitions.