### PR TITLE
better Nucleus compatibility + misc fixes

### DIFF
--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -56,6 +56,8 @@ namespace Celeste.Mod.CelesteNet.Client {
                     ExtraServersEntry.Disabled = value;
                 if (ResetGeneralButton != null)
                     ResetGeneralButton.Disabled = value;
+                if (ConnectLocallyButton != null)
+                    ConnectLocallyButton.Disabled = value;
             }
         }
         [SettingIgnore, YamlIgnore]
@@ -182,6 +184,11 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         [SettingIgnore, YamlIgnore]
         public uint InstanceID { get; set; } = 0;
+
+        [SettingIgnore, YamlIgnore]
+        public TextMenu.Button ConnectLocallyButton { get; protected set; }
+        [SettingIgnore, YamlIgnore]
+        public string HostOverride { get; set; } = "";
 
         [SettingIgnore, YamlIgnore]
         public TextMenu.Button ResetGeneralButton { get; protected set; }
@@ -925,9 +932,19 @@ namespace Celeste.Mod.CelesteNet.Client {
                 AutoReconnect = true;
                 ReceivePlayerAvatars = true;
                 ClientID = GenerateClientID();
+                HostOverride = "";
             });
             ResetGeneralButton.AddDescription(menu, "modoptions_celestenetclient_resetgeneralhint".DialogClean());
             ResetGeneralButton.Disabled = Connected;
+        }
+
+        public void CreateConnectLocallyButtonEntry(TextMenu menu, bool inGame) {
+            ConnectLocallyButton = CreateMenuButton(menu, "CONNECTLOCALLY", null, () => {
+                HostOverride = "localhost";
+                Connected = true;
+            });
+            ConnectLocallyButton.AddDescription(menu, "modoptions_celestenetclient_connectlocallyhint".DialogClean());
+            ConnectLocallyButton.Disabled = Connected;
         }
 
         public void CreateAutoReconnectEntry(TextMenu menu, bool inGame) {

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -79,7 +79,7 @@ namespace Celeste.Mod.CelesteNet.Client {
 #endif
         [SettingSubText("modoptions_celestenetclient_devonlyhint")]
         public string Server {
-            get => _Server;
+            get => ServerOverride.IsNullOrEmpty() ? _Server : ServerOverride;
             set {
                 if (_Server == value)
                     return;
@@ -91,6 +91,11 @@ namespace Celeste.Mod.CelesteNet.Client {
             }
         }
         private string _Server = DefaultServer;
+
+        // Any non-empty string will override Server property temporarily. (setting not saved)
+        // Currently only used for "connect locally" button (for Nucleus etc.)
+        [SettingIgnore, YamlIgnore]
+        public string ServerOverride { get; set; } = "";
 
         [SettingIgnore, YamlIgnore]
         public TextMenu.Button ServerEntry { get; protected set; }
@@ -185,10 +190,10 @@ namespace Celeste.Mod.CelesteNet.Client {
         [SettingIgnore, YamlIgnore]
         public uint InstanceID { get; set; } = 0;
 
+        public ClientIDSendMode ClientIDSending { get; set; } = ClientIDSendMode.NotOnLocalhost;
+
         [SettingIgnore, YamlIgnore]
         public TextMenu.Button ConnectLocallyButton { get; protected set; }
-        [SettingIgnore, YamlIgnore]
-        public string HostOverride { get; set; } = "";
 
         [SettingIgnore, YamlIgnore]
         public TextMenu.Button ResetGeneralButton { get; protected set; }
@@ -932,7 +937,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                 AutoReconnect = true;
                 ReceivePlayerAvatars = true;
                 ClientID = GenerateClientID();
-                HostOverride = "";
+                ServerOverride = "";
             });
             ResetGeneralButton.AddDescription(menu, "modoptions_celestenetclient_resetgeneralhint".DialogClean());
             ResetGeneralButton.Disabled = Connected;
@@ -940,7 +945,7 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public void CreateConnectLocallyButtonEntry(TextMenu menu, bool inGame) {
             ConnectLocallyButton = CreateMenuButton(menu, "CONNECTLOCALLY", null, () => {
-                HostOverride = "localhost";
+                ServerOverride = "localhost";
                 Connected = true;
             });
             ConnectLocallyButton.AddDescription(menu, "modoptions_celestenetclient_connectlocallyhint".DialogClean());
@@ -993,6 +998,12 @@ namespace Celeste.Mod.CelesteNet.Client {
             InvalidLength,
             InvalidChars,
             InvalidKey
+        }
+
+        public enum ClientIDSendMode {
+            Off = 0,
+            NotOnLocalhost = 1,
+            On = 2
         }
     }
 

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -190,6 +190,7 @@ namespace Celeste.Mod.CelesteNet.Client {
         [SettingIgnore, YamlIgnore]
         public uint InstanceID { get; set; } = 0;
 
+        [SettingIgnore]
         public ClientIDSendMode ClientIDSending { get; set; } = ClientIDSendMode.NotOnLocalhost;
 
         [SettingIgnore, YamlIgnore]

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -1,9 +1,9 @@
-﻿using Celeste.Mod.CelesteNet.Client.Components;
+﻿using System;
+using System.Linq;
+using Celeste.Mod.CelesteNet.Client.Components;
 using Celeste.Mod.UI;
 using Microsoft.Xna.Framework.Input;
 using Monocle;
-using System;
-using System.Linq;
 using YamlDotNet.Serialization;
 
 namespace Celeste.Mod.CelesteNet.Client {
@@ -21,7 +21,7 @@ namespace Celeste.Mod.CelesteNet.Client {
         public int Version {
             get => SettingsVersionDoNotEdit;
             set {
-                if (SettingsVersionDoNotEdit < value && value <= SettingsVersionCurrent)
+                if (SettingsVersionDoNotEdit <= value && value <= SettingsVersionCurrent)
                     SettingsVersionDoNotEdit = value;
                 else
                     Logger.LogDetailed(LogLevel.WRN, "CelesteNetClientSettings", $"Attempt to change Settings.Version from {SettingsVersionDoNotEdit} to {value} which is not allowed!");

--- a/CelesteNet.Client/DebugCommands.cs
+++ b/CelesteNet.Client/DebugCommands.cs
@@ -1,14 +1,13 @@
 ﻿using Monocle;
 
-namespace Celeste.Mod.CelesteNet.Client
-{
+namespace Celeste.Mod.CelesteNet.Client {
     public static class DebugCommands {
 
         [Command("con", "connect to a celestenet server")]
         public static void Con(string server) {
             CelesteNetClientModule.Settings.Connected = false;
             if (!string.IsNullOrWhiteSpace(server)) {
-                CelesteNetClientModule.Settings.Server = server;
+                CelesteNetClientModule.Settings.HostOverride = server;
             }
             CelesteNetClientModule.Settings.Connected = true;
         }

--- a/CelesteNet.Client/DebugCommands.cs
+++ b/CelesteNet.Client/DebugCommands.cs
@@ -7,7 +7,7 @@ namespace Celeste.Mod.CelesteNet.Client {
         public static void Con(string server) {
             CelesteNetClientModule.Settings.Connected = false;
             if (!string.IsNullOrWhiteSpace(server)) {
-                CelesteNetClientModule.Settings.HostOverride = server;
+                CelesteNetClientModule.Settings.ServerOverride = server;
             }
             CelesteNetClientModule.Settings.Connected = true;
         }

--- a/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
+++ b/CelesteNet.Server.FrontendModule/WSCMDs/WSCMDTag.cs
@@ -10,7 +10,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 return false;
             info.Tags.Add(tag);
             Frontend.Server.UserData.Save(uid, info);
-            Frontend.TaggedUsers.Add(uid, info);
+            Frontend.TaggedUsers[uid] = info;
             if (tag == BasicUserInfo.TAG_AUTH || tag == BasicUserInfo.TAG_AUTH_EXEC)
                 Frontend.Server.UserData.Create(uid, true);
             return true;

--- a/CelesteNet.Server.SqliteModule/SqliteUserData.cs
+++ b/CelesteNet.Server.SqliteModule/SqliteUserData.cs
@@ -36,6 +36,9 @@ namespace Celeste.Mod.CelesteNet.Server.Sqlite {
             _userDataRoot = userDataRoot;
             _dbName = dbName;
 
+            if (!Directory.Exists(UserDataRoot))
+                Directory.CreateDirectory(UserDataRoot);
+
             if (!File.Exists(DBPath)) {
                 using MiniCommand mini = new(this) {
                     SqliteOpenMode.ReadWriteCreate,

--- a/CelesteNet.Server/CelesteNetPlayerSession.cs
+++ b/CelesteNet.Server/CelesteNetPlayerSession.cs
@@ -255,7 +255,7 @@ namespace Celeste.Mod.CelesteNet.Server {
             playerInfo.Meta = playerInfo.GenerateMeta(Server.Data);
             Server.Data.SetRef(playerInfo);
 
-            Logger.Log(LogLevel.INF, "playersession", $"Session #{SessionID} PlayerInfo: {playerInfo}");
+            Logger.Log(LogLevel.INF, "playersession", $"Session #{SessionID} PlayerInfo: {playerInfo} (UID: {UID}; Con: {Con.UID})");
             Logger.Log(LogLevel.VVV, "playersession", $"Session #{SessionID} @ {DateTime.UtcNow.Ticks / TimeSpan.TicksPerMillisecond}");
 
             // Send packets to players
@@ -437,7 +437,7 @@ namespace Celeste.Mod.CelesteNet.Server {
             if (Interlocked.Exchange(ref _Alive, 0) <= 0)
                 return;
 
-            Logger.Log(LogLevel.INF, "playersession", $"Shutdown #{SessionID} {Con}");
+            Logger.Log(LogLevel.INF, "playersession", $"Shutdown #{SessionID} {Con} (Session UID: {UID}; PlayerInfo: {PlayerInfo})");
 
             DataPlayerInfo? playerInfoLast = PlayerInfo;
 

--- a/CelesteNet.Server/ConPlus/HandshakerRole.cs
+++ b/CelesteNet.Server/ConPlus/HandshakerRole.cs
@@ -396,10 +396,14 @@ Who wants some tea?"
                 return string.Format(Server.Settings.MessageAuthOnly, nameKey);
 
             // Check if the player's banned
-            if (Server.UserData.TryLoad(playerUID, out BanInfo banInfo) && (banInfo.From == null || banInfo.From <= DateTime.Now) && (banInfo.To == null || DateTime.Now <= banInfo.To))
-                banReason = banInfo;
-            if (Server.UserData.TryLoad(conUID, out BanInfo conBanInfo) && (conBanInfo.From == null || conBanInfo.From <= DateTime.Now) && (conBanInfo.To == null || DateTime.Now <= conBanInfo.To))
+            if (Server.UserData.TryLoad(conUID, out BanInfo conBanInfo) && (conBanInfo.From == null || conBanInfo.From <= DateTime.Now) && (conBanInfo.To == null || DateTime.Now <= conBanInfo.To)) {
+                Logger.Log(LogLevel.INF, "teapot", $"While authenticating conUID '{conUID}' found ban for '{conBanInfo.UID}': {conBanInfo.Reason}");
                 banReason = conBanInfo;
+            }
+            if (Server.UserData.TryLoad(playerUID, out BanInfo banInfo) && (banInfo.From == null || banInfo.From <= DateTime.Now) && (banInfo.To == null || DateTime.Now <= banInfo.To)) {
+                Logger.Log(LogLevel.INF, "teapot", $"While authenticating playerUID '{playerUID}' found ban for '{conBanInfo.UID}': {conBanInfo.Reason}");
+                banReason = banInfo;
+            }
             if (banReason != null)
                 return string.Format(Server.Settings.MessageBan, playerUID, playerName, banReason.Reason);
 

--- a/CelesteNet.Server/ConPlus/HandshakerRole.cs
+++ b/CelesteNet.Server/ConPlus/HandshakerRole.cs
@@ -401,7 +401,7 @@ Who wants some tea?"
                 banReason = conBanInfo;
             }
             if (Server.UserData.TryLoad(playerUID, out BanInfo banInfo) && (banInfo.From == null || banInfo.From <= DateTime.Now) && (banInfo.To == null || DateTime.Now <= banInfo.To)) {
-                Logger.Log(LogLevel.INF, "teapot", $"While authenticating playerUID '{playerUID}' found ban for '{conBanInfo.UID}': {conBanInfo.Reason}");
+                Logger.Log(LogLevel.INF, "teapot", $"While authenticating playerUID '{playerUID}' found ban for '{banInfo.UID}': {banInfo.Reason}");
                 banReason = banInfo;
             }
             if (banReason != null)

--- a/CelesteNet.Server/ConPlus/TCPUDPConnection.cs
+++ b/CelesteNet.Server/ConPlus/TCPUDPConnection.cs
@@ -1,8 +1,8 @@
-using Celeste.Mod.CelesteNet.DataTypes;
 using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Threading;
+using Celeste.Mod.CelesteNet.DataTypes;
 
 namespace Celeste.Mod.CelesteNet.Server {
     public class ConPlusTCPUDPConnection : CelesteNetTCPUDPConnection {

--- a/CelesteNet.Server/FileSystemUserData.cs
+++ b/CelesteNet.Server/FileSystemUserData.cs
@@ -14,6 +14,8 @@ namespace Celeste.Mod.CelesteNet.Server {
 
         public FileSystemUserData(CelesteNetServer server)
             : base(server) {
+            if (!Directory.Exists(UserRoot))
+                Directory.CreateDirectory(UserRoot);
         }
 
         public override void Dispose() {

--- a/CelesteNet.Shared/DataTypes/DataChat.cs
+++ b/CelesteNet.Shared/DataTypes/DataChat.cs
@@ -100,7 +100,7 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
             => ToString(true, false);
 
 
-        public string ToString(bool useDisplayName, bool withID) {
+        public string ToString(bool useDisplayName, bool withID, bool withSessID = false) {
             string id = "";
             if (withID)
                 id = $"{{{ID}v{Version}}}";
@@ -110,6 +110,8 @@ namespace Celeste.Mod.CelesteNet.DataTypes {
                 tag = $"[{Tag}]";
 
             string? username = useDisplayName ? Player?.DisplayName : Player?.FullName;
+            if (withSessID && Player != null)
+                username = $"(#{Player.ID}) {username}";
             username ??= "**SERVER**";
 
             if (TryGetSingleTarget(out DataPlayerInfo? target) && target != null)

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -45,6 +45,8 @@
 	MODOPTIONS_CELESTENETCLIENT_KEYERROR_INVALIDLENGTH=   :celestenet_warning: Key must have length 16 - check your input
 
 	MODOPTIONS_CELESTENETCLIENT_RESETGENERAL=	Reset General Settings
+	MODOPTIONS_CELESTENETCLIENT_CONNECTLOCALLY=	Connect to local server
+	MODOPTIONS_CELESTENETCLIENT_CONNECTLOCALLYHINT=	Temporarily try connecting to server on "localhost" (this PC, e.g. for Nucleus)
 	MODOPTIONS_CELESTENETCLIENT_RESETGENERALHINT=	Resets the options above to defaults, excluding Name/Key
 	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNELNAME=			Hide Your Channel Name
 	MODOPTIONS_CELESTENETCLIENT_HIDEOWNCHANNELHINT=		Intended for streamers.{n}Prevents leaking your channel name when receiving a message or opening the player list.


### PR DESCRIPTION
1. Finally remembered that comparison operator in CelesteNetClientSettings.Version setter that causes log spam with TAS or something.
2. UserData modules create the directory path they need if it isn't there instead of server failing to start when "UserData" folder is missing.
3. Add fallback default value for Settings.NetPlusThreadPoolThreads if it's too low or Environment.ProcessorCount couldn't be determined. It'll run with 5 Threads because it launches with 5 roles that need 1 thread minimum each, it'll just be unable to scale roles.
4. Added some logging related changes that have always annoyed me when grepping:
 - "[playersession]" Session #xxx / Shutdown #xxx lines now include player UID instead of just Con.UID
5.  switch the order in which authentication checks for bans, to check conUID first and playerUID second because the last of the two will be returned, it made more sense to me to check player UID last,
6. throw extra logging statements in `AuthenticatePlayerNameKey` because that's the easiest way to log if someone failed to connect because of an actual UID ban or because of IP ban
 - chat message logging had logging prefixes "chatmsg" and "chatupd" with "chatupd" for things generated/overriden by Server messages, but this included messages generated by "/gc ..." for example.
 - Now there's "chatmsg" for global chat, "chatetc" for non-global chat, "chatcmd" for commands and "chatupd" still for other server-generated.
7. Add button in Mod Options that sets new `ServerOverride` settings property which does just what the name suggests -- set a value that the `Server` getter will return instead, except this override is temporary and resets after game restart etc.
The `con` debug command now also sets `ServerOverride` instead of permanently messing with the config file.
Plus there's a button for connecting to `localhost` with this new override, meant for Nucleus local co-op.
8. New setting that doesn't show up in Mod Options: `ClientIDSending` with values:
```cs
enum ClientIDSendMode {
    Off = 0,
    NotOnLocalhost = 1,
    On = 2
}
```
Wondering right now if there should be an `OfficialServerOnly` value but eh, if that's needed somehow, can just set this to Off.