### PR TITLE
Client reconnect cooldown

### DIFF
--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -335,7 +335,7 @@ namespace Celeste.Mod.CelesteNet.Client {
             } else if (++ReconnectWaitRepetitions > FastReconnectPenaltyAfter || ReconnectWaitTime == FastReconnectPenaltyInitial) {
                 // increasing penalty after N tries, reset counter
                 if (ReconnectWaitTime < FastReconnectPenaltyMax)
-                    ReconnectWaitTime += FastReconnectPenalty;
+                    ReconnectWaitTime += FastReconnectPenalty + Calc.Random.Next(FastReconnectPenalty);
                 else
                     ReconnectWaitTime = FastReconnectPenaltyMax;
                 ReconnectWaitRepetitions = 0;
@@ -376,7 +376,7 @@ namespace Celeste.Mod.CelesteNet.Client {
             if (ReconnectWaitTime == 0) {
                 Logger.Log(LogLevel.DBG, "reconnect-attempt", $"CelesteNetClientModule Start: Setting initial reconnect delay from {ReconnectWaitTime} seconds to {FastReconnectPenaltyInitial}... (started {ReconnectDelayingSince})");
                 ReconnectDelayingSince = DateTime.UtcNow;
-                ReconnectWaitTime = FastReconnectPenaltyInitial;
+                ReconnectWaitTime = FastReconnectPenaltyInitial + Calc.Random.Next(FastReconnectPenaltyInitial);
             }
 
             Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientModule Start: Creating StartThread...");

--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -39,6 +39,27 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public DataDisconnectReason lastDisconnectReason;
 
+        // simply tracking when the last connection attempt to server was made
+        public DateTime LastConnectionAttempt { get; private set; } = DateTime.UtcNow;
+        // Repeated connection attempts will incur an incremental delay, this tracks when this started
+        public DateTime ReconnectDelayingSince { get; private set; } = DateTime.UtcNow;
+        // the current wait time in seconds between connection attempts
+        public int ReconnectWaitTime { get; private set; } = 0;
+        // wait time increases only happen after X tries at current delay, so track repeats
+        public int ReconnectWaitRepetitions { get; private set; } = 0;
+        // the delay applied on first reconnect retry
+        public const int FastReconnectPenaltyInitial = 2;
+        // the highest delay that can be reached
+        public const int FastReconnectPenaltyMax = 15;
+        // the delay in seconds that gets added at each increment
+        public const int FastReconnectPenalty = 3;
+        // the amount of retries that happen at each interval before incrementing wait time
+        public const int FastReconnectPenaltyAfter = 2;
+        // the amount of seconds that need to pass without attempts until delay resets
+        public const int FastReconnectResetAfter = 30;
+
+        public bool MayReconnect => (DateTime.UtcNow - LastConnectionAttempt).TotalSeconds > ReconnectWaitTime;
+
         public VirtualRenderTarget UIRenderTarget;
 
         // This should ideally be part of the "emote module" if emotes were a fully separate thing.
@@ -298,6 +319,35 @@ namespace Celeste.Mod.CelesteNet.Client {
 
             lastDisconnectReason = null;
 
+            if (!Settings.WantsToBeConnected) {
+                Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientModule Start: WantsToBeConnected has been set to {Settings.WantsToBeConnected}, canceling.");
+                return;
+            }
+
+            // check if wait time still applies
+            if (!MayReconnect) {
+                Logger.Log(LogLevel.INF, "reconnect-attempt", $"CelesteNetClientModule Start: Waiting {ReconnectWaitTime} seconds before next reconnect...");
+                QueuedTaskHelper.Do(new Tuple<object, string>(this, "CelesteNetAutoReconnect"), ReconnectWaitTime, () => {
+                        Logger.Log(LogLevel.DEV, "reconnect-attempt", $"CelesteNetClientContext - QueueTask: Calling instance Start");
+                        Instance.Start();
+                });
+                return;
+            } else if (++ReconnectWaitRepetitions > FastReconnectPenaltyAfter || ReconnectWaitTime == FastReconnectPenaltyInitial) {
+                // increasing penalty after N tries, reset counter
+                if (ReconnectWaitTime < FastReconnectPenaltyMax)
+                    ReconnectWaitTime += FastReconnectPenalty;
+                else
+                    ReconnectWaitTime = FastReconnectPenaltyMax;
+                ReconnectWaitRepetitions = 0;
+            }
+            
+            // fully reset wait time
+            if ((DateTime.UtcNow - LastConnectionAttempt).TotalSeconds > FastReconnectResetAfter && ReconnectWaitTime > 0) {
+                Logger.Log(LogLevel.INF, "reconnect-attempt", $"CelesteNetClientModule Start: Resetting reconnect delay from {ReconnectWaitTime} seconds to 0... (started {ReconnectDelayingSince})");
+                ReconnectWaitTime = 0;
+                ReconnectWaitRepetitions = 0;
+            }
+
             lock (ClientLock) {
                 Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientModule Start: old ctx: {Context} {Context?.IsDisposed}");
                 CelesteNetClientContext oldCtx = Context;
@@ -320,6 +370,15 @@ namespace Celeste.Mod.CelesteNet.Client {
                 Context.Status.Set("Initializing...");
             }
 
+            LastConnectionAttempt = DateTime.UtcNow;
+
+            // ReconnectDelayingSince shall track the time when connection attempts started, prior to any delays
+            if (ReconnectWaitTime == 0) {
+                Logger.Log(LogLevel.DBG, "reconnect-attempt", $"CelesteNetClientModule Start: Setting initial reconnect delay from {ReconnectWaitTime} seconds to {FastReconnectPenaltyInitial}... (started {ReconnectDelayingSince})");
+                ReconnectDelayingSince = DateTime.UtcNow;
+                ReconnectWaitTime = FastReconnectPenaltyInitial;
+            }
+
             Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientModule Start: Creating StartThread...");
             _StartThread = new(() => {
                 CelesteNetClientContext context = Context;
@@ -332,6 +391,7 @@ namespace Celeste.Mod.CelesteNet.Client {
 
                     context.Init(Settings);
                     context.Status.Set("Connecting...");
+
                     using (_StartTokenSource) {
                         Logger.Log(LogLevel.DEV, "lifecycle", $"CelesteNetClientModule StartThread: Going into context Start...");
                         context.Start(_StartTokenSource.Token);
@@ -358,6 +418,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                             _StartThread = null;
                             Stop();
                             context.Status.Set(ceee.Status ?? "Connection failed", 3f, false);
+                            Settings.KeyError = CelesteNetClientSettings.KeyErrors.None;
                             if (ceee.StatusCode == 403)
                                 Settings.KeyError = CelesteNetClientSettings.KeyErrors.InvalidKey;
                             handled = true;
@@ -376,6 +437,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                 } finally {
                     _StartThread = null;
                     _StartTokenSource = null;
+                    LastConnectionAttempt = DateTime.UtcNow;
                 }
             }) {
                 Name = "CelesteNet Client Start",

--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -326,11 +326,13 @@ namespace Celeste.Mod.CelesteNet.Client {
 
             // check if wait time still applies
             if (!MayReconnect) {
-                Logger.Log(LogLevel.INF, "reconnect-attempt", $"CelesteNetClientModule Start: Waiting {ReconnectWaitTime} seconds before next reconnect...");
-                QueuedTaskHelper.Do(new Tuple<object, string>(this, "CelesteNetAutoReconnect"), ReconnectWaitTime, () => {
+                if (Settings.AutoReconnect) {
+                    Logger.Log(LogLevel.INF, "reconnect-attempt", $"CelesteNetClientModule Start: Waiting {ReconnectWaitTime} seconds before next reconnect...");
+                    QueuedTaskHelper.Do(new Tuple<object, string>(Context, "CelesteNetAutoReconnect"), ReconnectWaitTime, () => {
                         Logger.Log(LogLevel.DEV, "reconnect-attempt", $"CelesteNetClientContext - QueueTask: Calling instance Start");
                         Instance.Start();
-                });
+                    });
+                }
                 return;
             } else if (++ReconnectWaitRepetitions > FastReconnectPenaltyAfter || ReconnectWaitTime == FastReconnectPenaltyInitial) {
                 // increasing penalty after N tries, reset counter

--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -30,6 +30,8 @@ namespace Celeste.Mod.CelesteNet.Client {
 
         public CelesteNetClientContext ContextLast;
         public CelesteNetClientContext Context;
+
+        public CelesteNetClientContext AnyContext => Context ?? ContextLast;
         public CelesteNetClient Client => Context?.Client;
         private readonly object ClientLock = new();
 
@@ -419,7 +421,7 @@ namespace Celeste.Mod.CelesteNet.Client {
                             Logger.Log(LogLevel.CRI, "clientmod", $"Connection error:\n{e}");
                             _StartThread = null;
                             Stop();
-                            context.Status.Set(ceee.Status ?? "Connection failed", 3f, false);
+                            AnyContext.Status.Set(ceee.Status ?? "Connection failed", 3f, false);
                             Settings.KeyError = CelesteNetClientSettings.KeyErrors.None;
                             if (ceee.StatusCode == 403)
                                 Settings.KeyError = CelesteNetClientSettings.KeyErrors.InvalidKey;

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -39,7 +39,7 @@ namespace Celeste.Mod.CelesteNet.Client {
             set {
                 WantsToBeConnected = value;
 
-                if (value && !Connected && CelesteNetClientModule.Instance.MayReconnect) {
+                if (value && !Connected) {
                     CelesteNetClientModule.Instance.Start();
                 }
                 else if (!value && Connected) {

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -39,16 +39,11 @@ namespace Celeste.Mod.CelesteNet.Client {
             set {
                 WantsToBeConnected = value;
 
-                if (CelesteNetClientModule.Instance.MayReconnect) {
-                    // these only happen when "may reconnect" to
-                    // (a) not allow spamming connect attempts
-                    // (b) not "accidentally" cancel a delayed connection attempt
-                    // (on-going auto-reconnects still check WantsToBeConnected separately)
-                    if (value && !Connected) {
-                        CelesteNetClientModule.Instance.Start();
-                    }
-                    else if (!value && Connected)
-                        CelesteNetClientModule.Instance.Stop();
+                if (value && !Connected && CelesteNetClientModule.Instance.MayReconnect) {
+                    CelesteNetClientModule.Instance.Start();
+                }
+                else if (!value && Connected) {
+                    CelesteNetClientModule.Instance.Stop();
                 }
 
                 if (value && !CelesteNetClientModule.Instance.MayReconnect && !(CelesteNetClientModule.Instance.Client?.IsAlive ?? false))
@@ -841,6 +836,7 @@ namespace Celeste.Mod.CelesteNet.Client {
         }
         public void CreateKeyEntry(TextMenu menu, bool inGame)
         {
+            KeyError = KeyErrors.None;
             KeyEntry = CreateMenuStringInput(menu, "KEY", s => s.Replace("((key))", Key.Length > 0 ? KeyDisplayDialog(KeyError) : "-"), 17, () => Key, newVal => Key = newVal);
             KeyEntry.AddDescription(menu, "modoptions_celestenetclient_keyhint".DialogClean());
             SetKeyEntryDisabled(inGame || Connected || _loginMode != LoginModeType.Key);

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -40,14 +40,13 @@ namespace Celeste.Mod.CelesteNet.Client {
                 WantsToBeConnected = value;
 
                 if (value && !Connected) {
+                    if (!CelesteNetClientModule.Instance.MayReconnect && !(CelesteNetClientModule.Instance.AnyContext?.Client?.IsAlive ?? false))
+                        CelesteNetClientModule.Instance.AnyContext?.Status?.Set("Reconnect delayed...", 3f, true, false);
                     CelesteNetClientModule.Instance.Start();
                 }
                 else if (!value && Connected) {
                     CelesteNetClientModule.Instance.Stop();
                 }
-
-                if (value && !CelesteNetClientModule.Instance.MayReconnect && !(CelesteNetClientModule.Instance.Client?.IsAlive ?? false))
-                    CelesteNetClientModule.Instance.Context?.Status?.Set("Reconnect delayed...", 3f, false, false);
 
                 if (!value && EnabledEntry != null && Engine.Scene != null)
                     Engine.Scene.OnEndOfFrame += () => EnabledEntry?.LeftPressed();

--- a/CelesteNet.Client/CelesteNetClientTCPUDPConnection.cs
+++ b/CelesteNet.Client/CelesteNetClientTCPUDPConnection.cs
@@ -1,4 +1,3 @@
-using Celeste.Mod.CelesteNet.DataTypes;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
@@ -6,9 +5,9 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using Celeste.Mod.CelesteNet.DataTypes;
 
-namespace Celeste.Mod.CelesteNet.Client
-{
+namespace Celeste.Mod.CelesteNet.Client {
     public class CelesteNetClientTCPUDPConnection : CelesteNetTCPUDPConnection {
 
         public const int UDPBufferSize = 65536;
@@ -41,7 +40,7 @@ namespace Celeste.Mod.CelesteNet.Client
                     return;
                 Logger.Log(LogLevel.INF, "tcpudpcon", UseUDP ? "UDP connection died" : "Switching to TCP only");
                 if (Logger.Level <= LogLevel.DBG)
-                    CelesteNetClientModule.Instance?.Context?.Status?.Set(UseUDP ? "UDP connection died" : "Switching to TCP only", 3);
+                    CelesteNetClientModule.Instance?.AnyContext?.Status?.Set(UseUDP ? "UDP connection died" : "Switching to TCP only", 3);
             };
 
             TCPSendQueue = new();

--- a/CelesteNet.Shared/ConnectionTypes/CelesteNetConnection.cs
+++ b/CelesteNet.Shared/ConnectionTypes/CelesteNetConnection.cs
@@ -5,8 +5,7 @@ using System.Reflection;
 using System.Threading;
 using Celeste.Mod.CelesteNet.DataTypes;
 
-namespace Celeste.Mod.CelesteNet
-{
+namespace Celeste.Mod.CelesteNet {
     public abstract class CelesteNetConnection : IDisposable {
 
         public readonly string Creator = "Unknown";
@@ -101,6 +100,7 @@ namespace Celeste.Mod.CelesteNet
 
         protected abstract CelesteNetSendQueue? GetQueue(DataType data);
         protected virtual void SendNoQueue(DataType data) {
+            Logger.LogDetailed(LogLevel.WRN, "CelesteNetConnection", $"Connection {this} called SendNoQueue for '{data}' but it's not implemented at all.");
         }
 
         protected virtual void Receive(DataType data) {


### PR DESCRIPTION
All the new properties and variables in CelesteNetClientModule explain with their comments what's going on I think.

Makes it impossible to "spam" connection attempts by flipping the switch 20 times in a second as well.

I don't _know_ if this will help with server performance or anything because I haven't tested for that, but I imagine preventing the possibility of "many people caught in reconnect loops creating new sessions rapidly" would be desirable.

I also just remembered I meant to introduce a small element of randomness perhaps for when the server restarts and every client tries to reconnect, we can maybe set them off on slightly differing delays.