### PR TITLE
Use `Ordinal` instead of `InvariantCulture` comparison

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetChatComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetChatComponent.cs
@@ -744,7 +744,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 case CompletionType.Player:
                     DataPlayerInfo[] all = Client.Data.GetRefs<DataPlayerInfo>();
 
-                    Completion = all.Select(p => p.FullName).Where(name => name.StartsWith(partial, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                    Completion = all.Select(p => p.FullName).Where(name => name.StartsWith(partial, StringComparison.OrdinalIgnoreCase)).ToList();
                     break;
                 case CompletionType.Channel:
                     CelesteNetPlayerListComponent playerlist = (CelesteNetPlayerListComponent) Context.Components[typeof(CelesteNetPlayerListComponent)];
@@ -752,7 +752,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     if (Settings.PlayerListUI.HideOwnChannelName)
                         // don't accidentally leak the channel name via tab completions
                         channelNames = channelNames.Where(name => name != CurrentChannelName);
-                    Completion = channelNames.Where(name => name.StartsWith(partial, StringComparison.InvariantCultureIgnoreCase)).ToList() ?? Completion;
+                    Completion = channelNames.Where(name => name.StartsWith(partial, StringComparison.OrdinalIgnoreCase)).ToList() ?? Completion;
 
                     break;
 
@@ -1110,7 +1110,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 string typed = "", suggestion = "", suggestionPrefix = "", suggestionSuffix = "";
                 string prefix = Typing.Substring(0, _CursorIndex - CompletionPartial.Length);
 
-                if (match.StartsWith(CompletionPartial, StringComparison.InvariantCultureIgnoreCase)) {
+                if (match.StartsWith(CompletionPartial, StringComparison.OrdinalIgnoreCase)) {
                     typed = match.Substring(0, CompletionPartial.Length);
                     suggestion = match.Substring(CompletionPartial.Length);
                 } else {

--- a/CelesteNet.Server.ChatModule/CMDs/ParamArgs/ParamPlayerSession.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/ParamArgs/ParamPlayerSession.cs
@@ -30,11 +30,11 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
                 using (Chat.Server.ConLock.R()) {
                     session = 
                         // check for exact name
-                        env.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.Equals(raw, StringComparison.InvariantCultureIgnoreCase) ?? false) ??
+                        env.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.Equals(raw, StringComparison.OrdinalIgnoreCase) ?? false) ??
                         // check for partial name in channel
-                        env.Session?.Channel.Players.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(raw, StringComparison.InvariantCultureIgnoreCase) ?? false) ??
+                        env.Session?.Channel.Players.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(raw, StringComparison.OrdinalIgnoreCase) ?? false) ??
                         // check for partial name elsewhere
-                        env.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(raw, StringComparison.InvariantCultureIgnoreCase) ?? false);
+                        env.Server.Sessions.FirstOrDefault(session => session.PlayerInfo?.FullName.StartsWith(raw, StringComparison.OrdinalIgnoreCase) ?? false);
                 }
             }
             if (session == null && uint.TryParse(raw, out playerID)) {

--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPControl.cs
@@ -343,7 +343,7 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 if (search.IsNullOrEmpty())
                     return true;
 
-                if (info.Name.Contains(search, StringComparison.InvariantCultureIgnoreCase))
+                if (info.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
                     return true;
 
                 return false;


### PR DESCRIPTION
Invariant culture string comparisons normalize the string, which we don't want. Always use ordinal string comparisons instead; see [this article](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#string-operations-that-use-the-invariant-culture).

Using invariant culture crashes the game when typing `/tp tm` when a player with the username `™` is connected to the server, as `"™".StartsWith("tm", StringComparison.InvariantCultureIgnoreCase)` returns `true` and causes the length on line `1114` to be out of bounds.

https://github.com/0x0ade/CelesteNet/blob/27ac4d76f52f8bbade6e386a6891977f4c059e40/CelesteNet.Client/Components/CelesteNetChatComponent.cs#L1113-L1118

![image](https://github.com/user-attachments/assets/47dbb87b-375f-44af-b9d5-8ae62ca6975d)
