### PR TITLE
Clarify "Connect" option and show prompt to fix failing attempts to connect to non-default servers.

### DIFF
--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -70,7 +70,7 @@ namespace Celeste.Mod.CelesteNet.Client {
             private set {
                 _FailedReconnectCount = value;
 
-                if (value >= FailedReconnectThreshold && Settings.Server != CelesteNetClientSettings.DefaultServer) {
+                if (value >= FailedReconnectThreshold && Settings.EffectiveServer != CelesteNetClientSettings.DefaultServer) {
                     Settings.ConnectDefaultVisible = true;
                     Settings.WantsToBeConnected = false;
                 }
@@ -186,6 +186,14 @@ namespace Celeste.Mod.CelesteNet.Client {
             // .ga domains have become inaccessible for some people.
             if (string.IsNullOrWhiteSpace(Settings.Server) || Settings.Server == "celeste.0x0ade.ga" || Settings.Server == "celestenet.0x0ade.ga")
                 Settings.Server = CelesteNetClientSettings.DefaultServer;
+
+            // So I did an oopsie, with how the 'Server' property getter was for convenience returning the ServerOverride when it's set,
+            // but I had entirely forgotten that this actual getter value will be saved to the settings file... for some reason I didn't think of this
+            // and obviously didn't intend it this way.
+            // So uhm, for the next month only, reset people who have "Server: localhost" in their yaml? :catplush:
+            if (Settings.Server == "localhost" && DateTime.UtcNow.Month < 10 && DateTime.UtcNow.Year == 2024) {
+                Settings.Server = CelesteNetClientSettings.DefaultServer;
+            }
 
             if (Settings.Emotes == null || Settings.Emotes.Length == 0) {
                 Settings.Emotes = new string[] {

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -102,12 +102,7 @@ namespace Celeste.Mod.CelesteNet.Client {
         public string EffectiveServer {
             get => ServerOverride.IsNullOrEmpty() ? Server : ServerOverride;
             private set {
-                if (Server == value)
-                    return;
-
                 Server = value;
-
-                UpdateServerInDialogs();
             }
         }
 
@@ -117,7 +112,18 @@ namespace Celeste.Mod.CelesteNet.Client {
         [SettingIgnore]
 #endif
         [SettingSubText("modoptions_celestenetclient_devonlyhint")]
-        public string Server { get; set; } = DefaultServer;
+        public string Server {
+            get => _Server;
+            set {
+                if (_Server == value)
+                    return;
+
+                _Server = value;
+
+                UpdateServerInDialogs();
+            }
+        }
+        private string _Server = DefaultServer;
 
         // Any non-empty string will override Server property temporarily. (setting not saved)
         // Currently only used for "connect locally" button (for Nucleus etc.)

--- a/CelesteNet.Client/CelesteNetClientSettings.cs
+++ b/CelesteNet.Client/CelesteNetClientSettings.cs
@@ -78,10 +78,13 @@ namespace Celeste.Mod.CelesteNet.Client {
         public bool ConnectDefaultVisible {
             get => _ConnectDefaultVisible;
             set {
-                _ConnectDefaultVisible = value;
-
                 if (ConnectDefaultButton != null)
                     ConnectDefaultButton.Visible = value;
+
+                if (_ConnectDefaultVisible != value && ConnectDefaultButtonHint != null)
+                    ConnectDefaultButtonHint.FadeVisible = value;
+
+                _ConnectDefaultVisible = value;
             }
         }
 
@@ -925,7 +928,6 @@ namespace Celeste.Mod.CelesteNet.Client {
         }
 
         public void CreateExtraServersEntry(TextMenu menu, bool inGame) {
-#if DEBUG
             int selected = 0;
             for (int i = 0; i < ExtraServers.Length; i++)
                 if (ExtraServers[i] == Server)
@@ -962,6 +964,8 @@ namespace Celeste.Mod.CelesteNet.Client {
                 ExtraServersEntry.Visible = ExtraServers.Length > 0;
             });
             item.AddDescription(menu, "modoptions_celestenetclient_reloadhint".DialogClean());
+#if !DEBUG
+            item.Visible = ExtraServers.Length > 0;
 #endif
         }
 
@@ -1039,7 +1043,7 @@ namespace Celeste.Mod.CelesteNet.Client {
             ConnectDefaultButton.Visible = ConnectDefaultVisible;
         }
 
-        #endregion
+#endregion
 
         public static ulong GenerateClientID() {
             return ulong.Parse(Guid.NewGuid().ToString().Replace("-", "").Substring(0, 16), System.Globalization.NumberStyles.HexNumber);

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -24,8 +24,10 @@
 # GhostNet Module Options
 	MODOPTIONS_CELESTENETCLIENT_TITLE=			CelesteNet - Multiplayer
 
-	MODOPTIONS_CELESTENETCLIENT_CONNECTED=			Connected
+	MODOPTIONS_CELESTENETCLIENT_CONNECTED=			Connect to ((server))
 	MODOPTIONS_CELESTENETCLIENT_CONNECTEDHINT=			Try setting "Receive Player Avatars" OFF if you can't connect
+	MODOPTIONS_CELESTENETCLIENT_CONNECTDEFAULT=			:celestenet_warning: Connect to ((default))?
+	MODOPTIONS_CELESTENETCLIENT_CONNECTDEFAULTHINT=		:celestenet_warning: Connection to "((server))" failed or timed out.
 	MODOPTIONS_CELESTENETCLIENT_AVATARS=				Receive Player Avatars
 	MODOPTIONS_CELESTENETCLIENT_AVATARSHINT=			Tells the server not to send you any profile pics during handshake.
 	MODOPTIONS_CELESTENETCLIENT_AUTORECONNECT=			Auto Reconnect


### PR DESCRIPTION
**Edit:**
It has come to my attention, that I made a slight mess with the recent ServerOverride change in v2.4.0.
![image](https://github.com/user-attachments/assets/1e77a5f3-35e5-46d5-8741-4f9723679309)
My intention had been to make it transparent to the users of this whether an override is in effect or not. But I'd completely forgotten that this property directly gets saved to CelesteNet.Client settings file, so some people have ended up with
```yaml
Server: localhost
```
in their settings permanently which is explicitly what I wanted to avoid... so now there will be a bit of silly code to fix those people, at the minor expense of people who would actually have wanted to permanently use `Server: localhost`.
![image](https://github.com/user-attachments/assets/22810ec5-88af-4723-95af-5f17a837ea34)
_(This of course with a reverted "dumb" implementation of `Server`, and the "smart" one is now `EffectiveServer` with a private setter, and with full YamlIgnore/SettingsIgnore)_

---

**Original PR**
The 'Connected' options is now named 'Connect to <server>' with name of `Server` setting. If multiple connection attempts fail and `Server` is not the `DefaultServer`, a button pops up right below the Connect toggle to connect back to official default server.

Also this sneaks in the fix(?) for the bizarre NullRef exception on the `_StartThread.Join();` line that previously was l. 469 in `CelesteNetClientModule.cs`
_(it now simply reads `_StartThread?.Join();` and on \*one\* of the seemingly identical occurrences Sonar tells me the null-check is unnecessary...)_