### PR TITLE
Proof of concept: Generic OAuth

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
@@ -98,6 +98,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         public void Handle(CelesteNetConnection con, DataNetEmoji netemoji) {
+            if (Client?.Options?.AvatarsDisabled == true)
+                return;
+
             lock (Pending) {
                 // Get the emoji asset
                 if (!Pending.TryGetValue(netemoji.ID, out NetEmojiAsset asset))

--- a/CelesteNet.Server.FrontendModule/FrontendSettings.cs
+++ b/CelesteNet.Server.FrontendModule/FrontendSettings.cs
@@ -22,6 +22,51 @@ namespace Celeste.Mod.CelesteNet.Server.Control
 
         public float NetPlusStatsUpdateRate { get; set; } = 1000;
 
+        public class OAuthProvider {
+            public string OAuthPathAuthorize { get; set; } = "";
+            public string OAuthPathToken { get; set; } = "";
+            public string OAuthScope { get; set; } = "identify";
+            public string OAuthClientID { get; set; } = "";
+            public string OAuthClientSecret { get; set; } = "";
+
+            public string ServiceUserAPI { get; set; } = "";
+
+            public string ServiceUserJsonPathUid { get; set; } = "$.id";
+
+            public string ServiceUserJsonPathName { get; set; } = "$.username";
+
+            public string ServiceUserJsonPathPfp { get; set; } = "$.avatar";
+
+            // will be put through string.Format with {0} = uid (ServiceUserJsonPathUid) and {1} = pfpFragment (ServiceUserJsonPathPfp)
+            public string ServiceUserAvatarURL { get; set; } = "";
+
+            public string ServiceUserAvatarDefaultURL { get; set; } = "";
+
+            public string OAuthURL(string redirectURL, string state) {
+                return $"{OAuthPathAuthorize}?client_id={OAuthClientID}&redirect_uri={Uri.EscapeDataString(redirectURL)}&response_type=code&scope={OAuthScope}&state={Uri.EscapeDataString(state)}";
+            }
+        }
+
+        public Dictionary<string,OAuthProvider> OAuthProviders { get; set; } = 
+            new Dictionary<string, OAuthProvider>() {
+                { "discord",
+                  new OAuthProvider()
+                  {
+                      OAuthPathAuthorize = "https://discord.com/oauth2/authorize",
+                      OAuthPathToken = "https://discord.com/api/oauth2/token",
+                      ServiceUserAPI = "https://discord.com/api/users/@me",
+                      ServiceUserJsonPathUid = "$.id",
+                      ServiceUserJsonPathName = "$.['global_name', 'username']",
+                      ServiceUserJsonPathPfp = "$.avatar",
+                      ServiceUserAvatarURL = "https://cdn.discordapp.com/avatars/{0}/{1}.png?size=64",
+                      ServiceUserAvatarDefaultURL = "https://cdn.discordapp.com/embed/avatars/0.png"
+                  }
+                }
+            };
+
+        [YamlIgnore]
+        public string OAuthRedirectURL => $"{CanonicalAPIRoot}/oauth";
+
         // TODO: Separate Discord auth module!
         [YamlIgnore]
         public string DiscordOAuthURL => $"https://discord.com/oauth2/authorize?client_id={DiscordOAuthClientID}&redirect_uri={Uri.EscapeDataString(DiscordOAuthRedirectURL)}&response_type=code&scope=identify";


### PR DESCRIPTION
Still a bunch of things I'd have to clean up, but this is more like what I had in mind for supporting arbitrary OAuth2 providers

1. Generate a random string for the OAuth2 "state" parameter, prefix it with the provider key (config name, e.g. "discord") and suffix with RSA signature of the random string (just a lil hack so that the state strings don't need to be tracked anywhere......)
2. Allow OAuth2 providers configured like so:
```
OAuthProviders:
  discord:
    OAuthPathAuthorize: https://discord.com/oauth2/authorize
    OAuthPathToken: https://discord.com/api/oauth2/token
    OAuthScope: identify
    OAuthClientID: xxx
    OAuthClientSecret: xxx
    ServiceUserAPI: https://discord.com/api/users/@me
    ServiceUserJsonPathUid: $.id
    ServiceUserJsonPathName: $.['global_name','username']
    ServiceUserJsonPathPfp: $.avatar
    ServiceUserAvatarURL: https://cdn.discordapp.com/avatars/{0}/{1}.png?size=64
    ServiceUserAvatarDefaultURL: https://cdn.discordapp.com/embed/avatars/0.png
```
_(YAML is absolute lunacy with how it doesn't serialize those JSONPaths as strings......)_
3. Advantages: When requesting `ServiceUserAPI` which we don't know what exactly it returns, just try to parse it with config-provided JSONPaths 🙂 
https://www.newtonsoft.com/json/help/html/QueryJsonSelectToken.htm
https://goessner.net/articles/JsonPath/

PS: ~~Don't mind the change in client EmojiComponent...... I was lazy with my unstaged changes :)~~ Moved that bit to #167 
