### PR TITLE
Fully ignore DataNetEmoji in Client when avatars are disabled (hide own avatar)

### DIFF
--- a/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetEmojiComponent.cs
@@ -98,6 +98,9 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
         }
 
         public void Handle(CelesteNetConnection con, DataNetEmoji netemoji) {
+            if (Client?.Options?.AvatarsDisabled == true)
+                return;
+
             lock (Pending) {
                 // Get the emoji asset
                 if (!Pending.TryGetValue(netemoji.ID, out NetEmojiAsset? asset))


### PR DESCRIPTION
This is a PR of two added lines, but I'm annoyed enough that I had accidentally committed this into #162 to pull it into this. 🤷 

This is because someone mentioned in #celestenet they would like to not have their own avatar showing up when own nametag is enabled and avatars are not, and that is indeed a bit of an oversight from when SJ release made me hack in avatar disabling to improve uh, handshake survival rate.