### PR TITLE
Use custom exception during data read/writes and just log them when they're caused by other mods' data

### DIFF
--- a/everest.pubclient.yaml
+++ b/everest.pubclient.yaml
@@ -1,5 +1,5 @@
 - Name: CelesteNet.Client
-  Version: 2.4.1
+  Version: 2.4.2
   DLL: CelesteNet.Client.dll
   Dependencies:
     - Name: EverestCore

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: CelesteNet.Client
-  Version: 2.4.1
+  Version: 2.4.2
   DLL: CelesteNet.Client/bin/Debug/net7.0/CelesteNet.Client.dll
   Dependencies:
     - Name: EverestCore


### PR DESCRIPTION
Better implementation of #164 

Added custom exception `DataContextException` into `CelesteNet.Shared/DataContext.cs`.

The exception has a `bool OtherMod` that is used in `CelesteNet.Client/CelesteNetClientTCPUDPConnection.cs` so stop the connection from dying if another mod caused it.
This probably won't work 100% of the time still because of potential read length mismatches on the socket streams, but at least this still does fix Avali disabled......