### PR TITLE
Session-Level Interactions Override

### DIFF
--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -28,6 +28,9 @@ namespace Celeste.Mod.CelesteNet.Client {
         public override Type SettingsType => typeof(CelesteNetClientSettings);
         public static CelesteNetClientSettings Settings => (CelesteNetClientSettings) Instance._Settings;
 
+        public override Type SessionType => typeof(CelesteNetClientSession);
+        public static CelesteNetClientSession Session => (CelesteNetClientSession)Instance._Session;
+
         public CelesteNetClientContext? ContextLast;
         public CelesteNetClientContext? Context;
 

--- a/CelesteNet.Client/CelesteNetClientModule.cs
+++ b/CelesteNet.Client/CelesteNetClientModule.cs
@@ -9,6 +9,7 @@ using Celeste.Mod.CelesteNet.Client.Components;
 using Celeste.Mod.CelesteNet.DataTypes;
 using FMOD.Studio;
 using Monocle;
+using MonoMod.ModInterop;
 using MonoMod.Utils;
 
 namespace Celeste.Mod.CelesteNet.Client {
@@ -108,6 +109,8 @@ namespace Celeste.Mod.CelesteNet.Client {
             Everest.Events.Celeste.OnShutdown += CelesteNetClientRC.Shutdown;
 
             CelesteNetClientSpriteDB.Load();
+
+            typeof(Interop).ModInterop();
         }
 
         public override void LoadContent(bool firstLoad) {

--- a/CelesteNet.Client/CelesteNetClientSession.cs
+++ b/CelesteNet.Client/CelesteNetClientSession.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.CelesteNet.Client {
+    public class CelesteNetClientSession : EverestModuleSession {
+        /// <summary>
+        /// Overrides the InGame.Interactions setting. null = use setting (do not override). Default is null.
+        /// </summary>
+        public bool? InteractionsOverride { get; set; } = null;
+
+        /// <summary>
+        /// Whether to use interactions in this session
+        /// </summary>
+        public bool UseInteractions => InteractionsOverride ?? CelesteNetClientModule.Settings?.InGame?.Interactions ?? false;
+    }
+}

--- a/CelesteNet.Client/Components/CelesteNetMainComponent.cs
+++ b/CelesteNet.Client/Components/CelesteNetMainComponent.cs
@@ -58,6 +58,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
 
         private ILHook? ILHookTransitionRoutine;
 
+        private bool Interactions_Safe => CelesteNetClientModule.Session?.UseInteractions ?? Settings?.InGame?.Interactions ?? true;
+
         public CelesteNetMainComponent(CelesteNetClientContext context, Game game)
             : base(context, game) {
 
@@ -231,7 +233,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     ghost == null)
                     return;
 
-                if (Settings.InGame.Interactions != state.Interactive && ghost == GrabbedBy)
+                if (Interactions_Safe != state.Interactive && ghost == GrabbedBy)
                     SendReleaseMe();
 
                 Session? session = Session;
@@ -498,10 +500,10 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 return;
 
             Player? player = Player;
-            if (player != null && !Settings.InGame.Interactions && (grab.Player.ID == Client.PlayerInfo.ID || grab.Grabbing.ID == Client.PlayerInfo.ID))
+            if (player != null && !Interactions_Safe && (grab.Player.ID == Client.PlayerInfo.ID || grab.Grabbing.ID == Client.PlayerInfo.ID))
                 goto Release;
 
-            if (Engine.Scene is not Level level || level.Paused || player == null || !Settings.InGame.Interactions)
+            if (Engine.Scene is not Level level || level.Paused || player == null || !Interactions_Safe)
                 return;
 
             if (grab.Player.ID != Client.PlayerInfo.ID && grab.Grabbing.ID == Client.PlayerInfo.ID) {
@@ -803,8 +805,8 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                 StateUpdated |= true;
             }
 
-            if (WasInteractive != Settings.InGame.Interactions) {
-                WasInteractive = Settings.InGame.Interactions;
+            if (WasInteractive != Interactions_Safe) {
+                WasInteractive = Interactions_Safe;
                 StateUpdated |= true;
             }
 
@@ -983,7 +985,7 @@ namespace Celeste.Mod.CelesteNet.Client.Components {
                     Mode = Session?.Area.Mode ?? MapEditorArea?.Mode ?? AreaMode.Normal,
                     Level = Session?.Level ?? (MapEditorArea != null ? LevelDebugMap : ""),
                     Idle = ForceIdle.Count != 0 || (Player?.Scene is Level level && (level.FrozenOrPaused || level.Overlay != null)),
-                    Interactive = Settings.InGame.Interactions
+                    Interactive = Interactions_Safe
                 });
             } catch (Exception e) {
                 Logger.Log(LogLevel.INF, "client-main", $"Error in SendState:\n{e}");

--- a/CelesteNet.Client/Entities/Ghost.cs
+++ b/CelesteNet.Client/Entities/Ghost.cs
@@ -115,7 +115,7 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         }
 
         public void OnPlayer(Player player) {
-            if (!Interactive || GrabCooldown > 0f || !CelesteNetClientModule.Settings.InGame.Interactions || Context?.Main?.GrabbedBy == this)
+            if (!Interactive || GrabCooldown > 0f || !CelesteNetClientModule.Session.UseInteractions || Context?.Main.GrabbedBy == this)
                 return;
 
             if (player.StateMachine.State == Player.StNormal &&
@@ -137,7 +137,7 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         }
 
         public void OnCarry(Vector2 position) {
-            if (!Interactive || GrabCooldown > 0f || !CelesteNetClientModule.Settings.InGame.Interactions || IdleTag != null)
+            if (!Interactive || GrabCooldown > 0f || !CelesteNetClientModule.Session.UseInteractions || IdleTag != null)
                 return;
 
             Position = position;
@@ -159,7 +159,7 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
         public void OnRelease(Vector2 force) {
             Collidable = true;
 
-            if (!Interactive || GrabCooldown > 0f || !CelesteNetClientModule.Settings.InGame.Interactions || IdleTag != null)
+            if (!Interactive || GrabCooldown > 0f || !CelesteNetClientModule.Session.UseInteractions || IdleTag != null)
                 return;
 
             CelesteNetClient? client = Context?.Client;
@@ -189,7 +189,7 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
                 return;
             }
 
-            bool holdable = Interactive && GrabCooldown <= 0f && CelesteNetClientModule.Settings.InGame.Interactions && IdleTag == null;
+            bool holdable = Interactive && GrabCooldown <= 0f && CelesteNetClientModule.Session.UseInteractions && IdleTag == null;
 
             GrabCooldown -= Engine.RawDeltaTime;
             if (GrabCooldown < 0f)

--- a/CelesteNet.Client/Interop.cs
+++ b/CelesteNet.Client/Interop.cs
@@ -1,0 +1,24 @@
+﻿using MonoMod.ModInterop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.CelesteNet.Client
+{
+    [ModExportName("CelesteNet.Client")]
+    public static class Interop
+    {
+        public static bool GetInteractions()
+            => CelesteNetClientModule.Session?.InteractionsOverride ?? CelesteNetClientModule.Settings?.InGame?.Interactions ?? false;
+
+        public static bool? GetInteractionsSessionOverride()
+            => CelesteNetClientModule.Session?.InteractionsOverride;
+
+        public static void SetInteractionsSessionOverride(bool? value) {
+            if (CelesteNetClientModule.Session != null)
+                CelesteNetClientModule.Session.InteractionsOverride = value;
+        }
+    }
+}


### PR DESCRIPTION
I want Co-op Helper to be able to override the celestenet interactions setting while in co-op maps, so that map designers can better control how the level is played. This PR creates a session level override for that setting and updates all references to respect it. It also creates a "CelesteNet.Client" ModInterop class to control how other mods (like Co-op Helper) are able to use it.