### PR TITLE
Sync the dash particle color of players

### DIFF
--- a/CelesteNet.Client/Entities/Ghost.cs
+++ b/CelesteNet.Client/Entities/Ghost.cs
@@ -357,6 +357,9 @@ namespace Celeste.Mod.CelesteNet.Client.Entities {
 
             if (colors.Length <= 0)
                 colors = new[] { Color.White };
+            else
+                Hair.Color = colors[0];
+                
             if (PlayerGraphics.HairCount < colors.Length)
                 Array.Resize(ref colors, PlayerGraphics.HairCount);
 


### PR DESCRIPTION
the DeathEffect of GhostDeadBody inherit the Hair.Color of Ghost. 
but the entire Ghost only sets Hair.Color to red when it is initialized.