### PR TITLE
Target Net 8.0 Core

### DIFF
--- a/CelesteNet.Client/CelesteNet.Client.csproj
+++ b/CelesteNet.Client/CelesteNet.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>CelesteNet.Client</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Client</RootNamespace>
       <!-->Nullable>disable</Nullable-->

--- a/CelesteNet.Server.ChatModule/CelesteNet.Server.ChatModule.csproj
+++ b/CelesteNet.Server.ChatModule/CelesteNet.Server.ChatModule.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>CelesteNet.Server.ChatModule</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Server.Chat</RootNamespace>
   </PropertyGroup>

--- a/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
+++ b/CelesteNet.Server.FrontendModule/CelesteNet.Server.FrontendModule.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>CelesteNet.Server.FrontendModule</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Server.Control</RootNamespace>
   </PropertyGroup>
@@ -15,17 +15,17 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
 
-      <PackageReference Include="SixLabors.ImageSharp" GeneratePathProperty="true" Version="3.1.4" />
+      <PackageReference Include="SixLabors.ImageSharp" GeneratePathProperty="true" Version="3.1.11" />
 
 
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" GeneratePathProperty="true" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" GeneratePathProperty="true" Version="2.1.7" />
 
       
-    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
 
     <!--
       this is a build of [websocket-sharp with custom headers](https://github.com/felixhao28/websocket-sharp)

--- a/CelesteNet.Server.SqliteModule/CelesteNet.Server.SqliteModule.csproj
+++ b/CelesteNet.Server.SqliteModule/CelesteNet.Server.SqliteModule.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>CelesteNet.Server.SqliteModule</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Server.Sqlite</RootNamespace>
   </PropertyGroup>
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" />
-    <PackageReference Include="MessagePack" Version="2.5.140" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.5.140">
+    <PackageReference Include="MessagePack" Version="2.5.198" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.5.198">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CelesteNet.Server/CelesteNet.Server.csproj
+++ b/CelesteNet.Server/CelesteNet.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <AssemblyName>CelesteNet.Server</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet.Server</RootNamespace>
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
   </ItemGroup>
 
   <Target Name="ClearModulesFolder" AfterTargets="AfterBuild" Condition="false">
@@ -32,15 +32,15 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
       
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" />
-    <PackageReference Include="MessagePack" Version="2.5.140" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.5.140">
+    <PackageReference Include="MessagePack" Version="2.5.198" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.5.198">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CelesteNet.Shared/CelesteNet.Shared.csproj
+++ b/CelesteNet.Shared/CelesteNet.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>CelesteNet.Shared</AssemblyName>
     <RootNamespace>Celeste.Mod.CelesteNet</RootNamespace>
   </PropertyGroup>

--- a/CelesteNet.props
+++ b/CelesteNet.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable Condition="'$(Nullable)' == ''">enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
@@ -37,8 +37,8 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="MonoMod.RuntimeDetour" Version="25.0.2" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="MonoMod.Utils" Version="25.0.3" />
+    <PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="MonoMod.Utils" Version="25.0.8" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
 

--- a/PublishClient.ps1
+++ b/PublishClient.ps1
@@ -3,7 +3,7 @@ Remove-Item -Recurse -Path PubClient
 Remove-Item -Path CelesteNet.Client.zip
 New-Item -ItemType directory -Path PubClient
 Copy-Item -Path everest.pubclient.yaml -Destination PubClient/everest.yaml
-Copy-Item -Recurse -Path CelesteNet.Client/bin/Release/net7.0/CelesteNet* -Destination PubClient
+Copy-Item -Recurse -Path CelesteNet.Client/bin/Release/net8.0/CelesteNet* -Destination PubClient
 Copy-Item -Recurse -Path Dialog -Destination PubClient
 Copy-Item -Recurse -Path Graphics -Destination PubClient
 Compress-Archive -Path PubClient/* -DestinationPath CelesteNet.Client.zip

--- a/PublishClient.sh
+++ b/PublishClient.sh
@@ -3,7 +3,7 @@ dotnet build CelesteNet.Client -c Release
 rm -rf PubClient CelesteNet.Client.zip
 mkdir PubClient
 cp everest.pubclient.yaml PubClient/everest.yaml
-cp -r CelesteNet.Client/bin/Release/net7.0/CelesteNet.* PubClient
+cp -r CelesteNet.Client/bin/Release/net8.0/CelesteNet.* PubClient
 [ -f PubClient/CelesteNet.Client.deps.json ] && rm PubClient/CelesteNet.Client.deps.json
 cp -r Dialog PubClient
 cp -r Graphics PubClient

--- a/everest.pubclient.yaml
+++ b/everest.pubclient.yaml
@@ -3,4 +3,4 @@
   DLL: CelesteNet.Client.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.4465.0
+      Version: 1.5577.0

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,6 +1,6 @@
 - Name: CelesteNet.Client
   Version: 2.4.2
-  DLL: CelesteNet.Client/bin/Debug/net7.0/CelesteNet.Client.dll
+  DLL: CelesteNet.Client/bin/Debug/net8.0/CelesteNet.Client.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.4465.0
+      Version: 1.5577.0


### PR DESCRIPTION
Upgraded all projects to target **net8.0** as required for building for Everest 5577+
(...and because it's LTS and such)

Upped the LangVersion from 11 to 12 as well, the latest version of C# supported by .NET 8.0
https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12

Also needs [MonoMod.RuntimeDetour](https://www.nuget.org/packages/MonoMod.RuntimeDetour) to be bumped from 25.0.2 to 25.3.0

Somewhat conservatively bumped other patch/minor releases of package deps:

**CelesteNet.props:**
[MonoMod.RuntimeDetour](https://www.nuget.org/packages/MonoMod.RuntimeDetour) -- 25.0.2 &rarr; 25.**3.0**
[MonoMod.Utils](https://www.nuget.org/packages/MonoMod.Utils) -- 25.0.3 &rarr; 25.0.**8**

**CelesteNet.Server.FrontendModule.csproj:**
[Microsoft.AspNetCore.StaticFiles](https://www.nuget.org/packages/Microsoft.AspNetCore.StaticFiles) -- 2.2.0 &rarr; 2.**3**.0
[SixLabors.ImageSharp](https://www.nuget.org/packages/SixLabors.ImageSharp) -- 3.1.4 &rarr; 3.1.**11** (addresses #171)
[SixLabors.ImageSharp.Drawing](https://www.nuget.org/packages/SixLabors.ImageSharp.Drawing) -- 2.1.3 &rarr; 2.1.**7**

[Microsoft.CodeAnalysis.Compilers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Compilers) -- 4.8.0 &rarr; 4.**14**.0
[Microsoft.CodeAnalysis.Common](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common) -- 4.8.0 &rarr; 4.**14**.0
[Microsoft.CodeAnalysis.CSharp](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp) -- 4.8.0 &rarr; 4.**14**.0

**CelesteNet.Server.SqliteModule.csproj:**
[MessagePack](https://www.nuget.org/packages/MessagePack) -- 2.5.140 &rarr; 2.5.**198** 
[MessagePackAnalyzer](https://www.nuget.org/packages/MessagePackAnalyzer) -- 2.5.140 &rarr; 2.5.**198** (addresses #166)

**CelesteNet.Server.csproj:**
[MessagePack](https://www.nuget.org/packages/MessagePack) -- 2.5.140 &rarr; 2.5.**198** 
[MessagePackAnalyzer](https://www.nuget.org/packages/MessagePackAnalyzer) -- 2.5.140 &rarr; 2.5.**198** (addresses #165)

[Mono.Cecil](https://www.nuget.org/packages/Mono.Cecil) -- 0.11.4 &rarr; 0.11.**6**
[Microsoft.AspNetCore.StaticFiles](https://www.nuget.org/packages/Microsoft.AspNetCore.StaticFiles) -- 2.2.0 &rarr; 2.**3**.0

[Microsoft.CodeAnalysis.Compilers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Compilers) -- 4.8.0 &rarr; 4.**14**.0
[Microsoft.CodeAnalysis.Common](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common) -- 4.8.0 &rarr; 4.**14**.0
[Microsoft.CodeAnalysis.CSharp](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp) -- 4.8.0 &rarr; 4.**14**.0

**_Could_** bump [Microsoft.Data.Sqlite](https://www.nuget.org/packages/Microsoft.Data.Sqlite) and System.Drawing.Common from 8.0.2 to latest patch or try 9.0.8
**_Could_** bump [YamlDotNet](https://www.nuget.org/packages/YamlDotNet) from 15.1.2 to 15.3.0 or 16.3.0
...but I left those untouched for now...

