### PR TITLE
Add marker interface for types that are saved/loaded to/from UserData?

### DIFF
--- a/CelesteNet.Server.ChatModule/CMDs/CmdTP.cs
+++ b/CelesteNet.Server.ChatModule/CMDs/CmdTP.cs
@@ -162,7 +162,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat.Cmd {
 
     }
 
-    public class TPSettings {
+    public class TPSettings : IUserDataType {
         public bool Enabled { get; set; } = true;
     }
 

--- a/CelesteNet.Server.ChatModule/ChatModule.cs
+++ b/CelesteNet.Server.ChatModule/ChatModule.cs
@@ -476,7 +476,7 @@ namespace Celeste.Mod.CelesteNet.Server.Chat {
                     player.Con?.Send(blob);
         }
 
-        public class UserChatSettings {
+        public class UserChatSettings : IUserDataType {
             public bool AutoChannelChat { get; set; } = false;
             public bool Whispers { get; set; } = true;
         }

--- a/CelesteNet.Server.SqliteModule/SqliteUserData.cs
+++ b/CelesteNet.Server.SqliteModule/SqliteUserData.cs
@@ -308,6 +308,7 @@ namespace Celeste.Mod.CelesteNet.Server.Sqlite {
                     default: {
                         using Stream stream = reader.GetStream(1);
                         value = MessagePackSerializer.Deserialize<T>(stream, MessagePackHelper.Options) ?? new();
+                        Logger.Log(LogLevel.DEV, "sqlite", $"Loaded MsgPack: {MessagePackSerializer.SerializeToJson<T>(value, MessagePackHelper.Options)}");
                         return true;
                     }
 

--- a/CelesteNet.Server/Channels.cs
+++ b/CelesteNet.Server/Channels.cs
@@ -256,7 +256,7 @@ namespace Celeste.Mod.CelesteNet.Server {
         }
     }
 
-    public class LastChannelUserInfo {
+    public class LastChannelUserInfo : IUserDataType {
         public string Name = "main";
     }
 }

--- a/CelesteNet.Server/FileSystemUserData.cs
+++ b/CelesteNet.Server/FileSystemUserData.cs
@@ -286,7 +286,7 @@ namespace Celeste.Mod.CelesteNet.Server {
             public Dictionary<string, string> UIDs { get; set; } = new();
         }
 
-        public class PrivateUserInfo {
+        public class PrivateUserInfo : IUserDataType {
             public string Key { get; set; } = "";
             public string KeyFull { get; set; } = "";
         }

--- a/CelesteNet.Server/UserData.cs
+++ b/CelesteNet.Server/UserData.cs
@@ -7,7 +7,7 @@ namespace Celeste.Mod.CelesteNet.Server {
 
         public readonly CelesteNetServer Server;
 
-        public UserData(CelesteNetServer server) {
+        protected UserData(CelesteNetServer server) {
             Server = server;
         }
 
@@ -18,19 +18,19 @@ namespace Celeste.Mod.CelesteNet.Server {
         public abstract string GetUID(string key);
         public abstract string GetKey(string uid);
 
-        public abstract bool TryLoad<T>(string uid, out T value) where T : new();
-        public T Load<T>(string uid) where T : new()
+        public abstract bool TryLoad<T>(string uid, out T value) where T : IUserDataType, new();
+        public T Load<T>(string uid) where T : IUserDataType, new()
             => TryLoad(uid, out T value) ? value : value;
         public abstract bool HasFile(string uid, string name);
         public abstract Stream? ReadFile(string uid, string name);
-        public abstract void Save<T>(string uid, T value) where T : notnull;
+        public abstract void Save<T>(string uid, T value) where T : notnull, IUserDataType;
         public abstract Stream WriteFile(string uid, string name);
-        public abstract void Delete<T>(string uid);
+        public abstract void Delete<T>(string uid) where T : IUserDataType;
         public abstract void DeleteFile(string uid, string name);
         public abstract void Wipe(string uid);
 
-        public abstract Dictionary<string, T> LoadRegistered<T>() where T : new();
-        public abstract Dictionary<string, T> LoadAll<T>() where T : new();
+        public abstract Dictionary<string, T> LoadRegistered<T>() where T : IUserDataType, new();
+        public abstract Dictionary<string, T> LoadAll<T>() where T : IUserDataType, new();
 
         public abstract string[] GetRegistered();
         public abstract string[] GetAll();
@@ -60,7 +60,9 @@ namespace Celeste.Mod.CelesteNet.Server {
 
     }
 
-    public class BasicUserInfo {
+    public interface IUserDataType { }
+
+    public class BasicUserInfo : IUserDataType {
         public static readonly string TAG_AUTH = "moderator";
         public static readonly string TAG_AUTH_EXEC = "admin";
         public static readonly IReadOnlyList<string> AUTH_TAGS = new List<string>() {
@@ -74,7 +76,7 @@ namespace Celeste.Mod.CelesteNet.Server {
         public HashSet<string> Tags { get; set; } = new();
     }
 
-    public class BanInfo {
+    public class BanInfo : IUserDataType {
         public string UID { get; set; } = "";
         public string Name { get; set; } = "";
         public string Reason { get; set; } = "";
@@ -82,7 +84,7 @@ namespace Celeste.Mod.CelesteNet.Server {
         public DateTime? To { get; set; } = null;
     }
 
-    public class KickHistory {
+    public class KickHistory : IUserDataType {
         public List<Entry> Log { get; set; } = new();
         public class Entry {
             public string Reason { get; set; } = "";


### PR DESCRIPTION
Add empty interface IUserDataType as a marker for types that go into UserData Save/Load functions.

I dunno if there are better ways of doing this, or if some people would argue it shouldn't be an empty interface to do this kinda thing, but eh. I'd at least like _some_ way to find all classes that have been scattered through the code base to be saved to UserData, and using this constraint works.

I think this doesn't affect existing data that had been serialized into SQLite before this change, at least in testing my DB loaded just fine. Hopefully that holds true.

(I almost went and adjusted the SQLite module "self-test" to compare itself to an existing DB file, but uhhhh... the whole self-test needs to be rewritten, idk what the hell I cooked there. Very cool...)