### PR TITLE
Access checks when re-linking Discord account or revoking key...

### DIFF
--- a/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
+++ b/CelesteNet.Server.FrontendModule/RCEPs/RCEPPublic.cs
@@ -104,6 +104,14 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 return;
             }
 
+            if (f.Server.UserData.TryLoad(uid, out BanInfo banInfo) && banInfo != null) {
+                c.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                f.RespondJSON(c, new {
+                    Error = "Unauthorized - access denied."
+                });
+                return;
+            }
+
             string key = f.Server.UserData.Create(uid, false);
             BasicUserInfo info = f.Server.UserData.Load<BasicUserInfo>(uid);
 
@@ -262,6 +270,14 @@ namespace Celeste.Mod.CelesteNet.Server.Control {
                 c.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
                 f.RespondJSON(c, new {
                     Error = "Unauthorized - invalid key."
+                });
+                return;
+            }
+
+            if (f.Server.UserData.TryLoad(uid, out BanInfo banInfo) && banInfo != null) {
+                c.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                f.RespondJSON(c, new {
+                    Error = "Unauthorized - access denied."
                 });
                 return;
             }


### PR DESCRIPTION
...and deny such attempts under certain circumstances. Specifically for banned users, there's no reason why they should be changing their key. Same for anything else that OAuth would be updating.
Especially when that just means a different key will show up in server logs for client connection attempts. There's really no need. 