### PR TITLE
Remove BOM from PublishClient.sh.

### DIFF
--- a/PublishClient.sh
+++ b/PublishClient.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 dotnet build CelesteNet.Client -c Release
 rm -rf PubClient CelesteNet.Client.zip
 mkdir PubClient


### PR DESCRIPTION
The PublishClient.sh file contained a Byte Order Mark at the start. This is an invisible byte sequence at the start of the file that exists mostly for legacy applications, but is not recommended. In this case, it caused the following mostly harmless error:
./PublishClient.sh: line 1: #!/bin/sh: No such file or directory

The "shebang" line has to be the first line with nothing before it, so the program loader throws this error since there is a byte sequence before it (the BOM).